### PR TITLE
Minor cleanup, prettier output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -271,8 +271,10 @@ fn display_node<S: Into<String>>(
     let mut is = indentation_str.into();
     print_this_node(node_to_print, is_first, depth, is.as_ref());
 
-    is = is.replace("└──", "   ");
-    is = is.replace("├──", "│  ");
+    is = is.replace("└─┬", "  ");
+    is = is.replace("└──", "  ");
+    is = is.replace("├──", "│ ");
+    is = is.replace("├─┬", "│ ");
 
     let printable_node_slashes = node_to_print.dir.name.matches('/').count();
 
@@ -287,15 +289,29 @@ fn display_node<S: Into<String>>(
     });
 
     let mut is_biggest = true;
+    let mut has_display_children = false;
     for node in to_display {
         if node_to_print.children.contains(node) {
+            let has_children = node.children.len() > 0;
             if node.dir.name.matches("/").count() == printable_node_slashes + 1 {
                 num_sibblings -= 1;
+                for ref n in node.children.iter() {
+                    has_display_children = has_display_children || to_display.contains(n);
+                }
+                let has_children = has_children && has_display_children;
                 let tree_chars = {
                     if num_sibblings == 0 {
-                        "└──"
+                        if has_children {
+                            "└─┬"
+                        } else {
+                            "└──"
+                        }
                     } else {
-                        "├──"
+                        if has_children {
+                            "├─┬"
+                        } else {
+                            "├──"
+                        }
                     }
                 };
                 display_node(

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,7 +278,7 @@ fn display_node<S: Into<String>>(
 
     let printable_node_slashes = node_to_print.dir.name.matches('/').count();
 
-    let mut num_sibblings = to_display.iter().fold(0, |a, b| {
+    let mut num_siblings = to_display.iter().fold(0, |a, b| {
         if node_to_print.children.contains(b)
             && b.dir.name.matches('/').count() == printable_node_slashes + 1
         {
@@ -294,13 +294,13 @@ fn display_node<S: Into<String>>(
         if node_to_print.children.contains(node) {
             let has_children = node.children.len() > 0;
             if node.dir.name.matches("/").count() == printable_node_slashes + 1 {
-                num_sibblings -= 1;
+                num_siblings -= 1;
                 for ref n in node.children.iter() {
                     has_display_children = has_display_children || to_display.contains(n);
                 }
                 let has_children = has_children && has_display_children;
                 let tree_chars = {
-                    if num_sibblings == 0 {
+                    if num_siblings == 0 {
                         if has_children {
                             "└─┬"
                         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,8 @@ impl Ord for Node {
         } else if self.dir.size < other.dir.size {
             Ordering::Greater
         } else {
-            let my_slashes = self.dir.name.matches("/").count();
-            let other_slashes = other.dir.name.matches("/").count();
+            let my_slashes = self.dir.name.matches('/').count();
+            let other_slashes = other.dir.name.matches('/').count();
 
             if my_slashes > other_slashes {
                 Ordering::Greater
@@ -68,7 +68,7 @@ struct Dir {
     size: u64,
 }
 
-static DEFAULT_NUMBER_OF_LINES: &'static str = &"15";
+static DEFAULT_NUMBER_OF_LINES: &'static str = "15";
 
 fn main() {
     let options = App::new("Trailing args example")
@@ -91,16 +91,16 @@ fn main() {
     };
     let number_of_lines = value_t!(options.value_of("number_of_lines"), usize).unwrap();
 
-    let (permissions, results) = get_dir_tree(filenames);
+    let (permissions, results) = get_dir_tree(&filenames);
     let slice_it = find_big_ones(&results, number_of_lines);
-    display(permissions, slice_it);
+    display(permissions, &slice_it);
 }
 
-fn get_dir_tree(filenames: Vec<&str>) -> (bool, Vec<Node>) {
+fn get_dir_tree(filenames: &Vec<&str>) -> (bool, Vec<Node>) {
     let mut permissions = true;
     let mut results = vec![];
     for b in filenames {
-        let mut new_name = String::from(b);
+        let mut new_name = String::from(*b);
         while new_name.chars().last() == Some('/') && new_name.len() != 1 {
             new_name.pop();
         }
@@ -274,11 +274,11 @@ fn display_node<S: Into<String>>(
     is = is.replace("└──", "   ");
     is = is.replace("├──", "│  ");
 
-    let printable_node_slashes = node_to_print.dir.name.matches("/").count();
+    let printable_node_slashes = node_to_print.dir.name.matches('/').count();
 
     let mut num_sibblings = to_display.iter().fold(0, |a, b| {
         if node_to_print.children.contains(b)
-            && b.dir.name.matches("/").count() == printable_node_slashes + 1
+            && b.dir.name.matches('/').count() == printable_node_slashes + 1
         {
             a + 1
         } else {
@@ -346,6 +346,7 @@ fn human_readable_number(size: u64) -> (String) {
 }
 
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,7 @@ fn find_big_ones<'a>(l: &'a Vec<Node>, max_to_show: usize) -> Vec<&Node> {
     }
 }
 
-fn display(permissions: bool, to_display: Vec<&Node>) -> () {
+fn display(permissions: bool, to_display: &Vec<&Node>) -> () {
     if !permissions {
         eprintln!("Did not have permissions for all directories");
     }


### PR DESCRIPTION
This is a really great little tool! I noticed some compiler warnings when I built it locally, and I thought the box construction characters could be slightly fancier, so there you go. I split the changes into several commits, and the only one that changes behavior is the last one, 1c80cbf, "Make printing slightly prettier." I'm not sure this PR is worth merging, just FYI. Also, I might change it a little more aggressively, like factor it into a lib crate and a bin crate, and possibly try to speed it up.