### PR TITLE
Clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,15 @@ dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "environment"
@@ -547,6 +553,7 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cdb90b60f2927f8d76139c72dbde7e10c3a2bc47c8594c9c7a66529f2687c03"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
+"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum environment 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ clap = "=2.33"
 assert_cli = "=0.5"
 tempfile = "=3"
 walkdir = "=2"
-
+either = "=1.5"

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,7 @@
 extern crate ansi_term;
 
+use either::*;
+
 use self::ansi_term::Colour::Fixed;
 use self::ansi_term::Style;
 use crate::utils::Node;
@@ -59,12 +61,11 @@ impl DisplayData {
         }
     }
 
-    fn get_children_from_node(&self, node: Node) -> impl Iterator<Item = Node> {
+    fn get_children_from_node(&self, node: Node) -> impl IntoIterator<Item = Node> {
         if self.is_reversed {
-            let n: Vec<Node> = node.children.into_iter().rev().map(|a| a).collect();
-            n.into_iter()
+            Left(node.children.into_iter().rev())
         } else {
-            node.children.into_iter()
+            Right(node.children.into_iter())
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -38,18 +38,16 @@ impl DisplayData {
             } else {
                 "├──"
             }
-        } else {
-            if num_siblings == 0 {
-                if has_children {
-                    "└─┬"
-                } else {
-                    "└──"
-                }
-            } else if has_children {
-                "├─┬"
+        } else if num_siblings == 0 {
+            if has_children {
+                "└─┬"
             } else {
-                "├──"
+                "└──"
             }
+        } else if has_children {
+            "├─┬"
+        } else {
+            "├──"
         }
     }
 
@@ -61,12 +59,12 @@ impl DisplayData {
         }
     }
 
-    fn get_children_from_node(&self, node: Node) -> impl Iterator<Item = Box<Node>> {
+    fn get_children_from_node(&self, node: Node) -> impl Iterator<Item = Node> {
         if self.is_reversed {
-            let n: Vec<Box<Node>> = node.children.into_iter().rev().map(|a| a).collect();
-            return n.into_iter();
+            let n: Vec<Node> = node.children.into_iter().rev().map(|a| a).collect();
+            n.into_iter()
         } else {
-            return node.children.into_iter();
+            node.children.into_iter()
         }
     }
 }
@@ -82,7 +80,7 @@ pub fn draw_it(permissions: bool, use_full_path: bool, is_reversed: bool, root_n
 
     for c in display_data.get_children_from_node(root_node) {
         let first_tree_chars = display_data.get_first_chars();
-        display_node(*c, true, first_tree_chars, &display_data)
+        display_node(c, true, first_tree_chars, &display_data)
     }
 }
 
@@ -101,10 +99,10 @@ fn display_node(node: Node, is_biggest: bool, indent: &str, display_data: &Displ
 
     for c in display_data.get_children_from_node(node) {
         num_siblings -= 1;
-        let chars = display_data.get_tree_chars(num_siblings, max_sibling, c.children.len() > 0);
+        let chars = display_data.get_tree_chars(num_siblings, max_sibling, !c.children.is_empty());
         let is_biggest = display_data.is_biggest(num_siblings, max_sibling);
         let full_indent = new_indent.clone() + chars;
-        display_node(*c, is_biggest, &*full_indent, display_data)
+        display_node(c, is_biggest, &*full_indent, display_data)
     }
 
     if display_data.is_reversed {

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,8 +140,7 @@ fn recursively_build_tree(parent_node: &mut Node, new_node: Node, depth: Option<
             return recursively_build_tree(&mut *c, new_node, new_depth);
         }
     }
-    let temp = Box::<Node>::new(new_node);
-    parent_node.children.push(temp);
+    parent_node.children.push(new_node);
 }
 
 #[cfg(test)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,7 +11,7 @@ use self::platform::*;
 pub struct Node {
     pub name: String,
     pub size: u64,
-    pub children: Vec<Box<Node>>,
+    pub children: Vec<Node>,
 }
 
 pub fn simplify_dir_names(filenames: Vec<&str>) -> HashSet<String> {

--- a/src/utils/platform.rs
+++ b/src/utils/platform.rs
@@ -1,5 +1,6 @@
 use walkdir::DirEntry;
 
+#[allow(dead_code)]
 fn get_block_size() -> u64 {
     // All os specific implementations of MetatdataExt seem to define a block as 512 bytes
     // https://doc.rust-lang.org/std/os/linux/fs/trait.MetadataExt.html#tymethod.st_blocks
@@ -21,5 +22,5 @@ pub fn get_metadata(d: &DirEntry, use_apparent_size: bool) -> Option<(u64, Optio
 
 #[cfg(not(target_family = "unix"))]
 pub fn get_metadata(d: &DirEntry, _apparent: bool) -> Option<(u64, Option<(u64, u64)>)> {
-    d.metadata().ok().map_or(None, |md| Some((md.len(), None)))
+    d.metadata().ok().map(|md| (md.len(), None))
 }

--- a/src/utils/platform.rs
+++ b/src/utils/platform.rs
@@ -10,12 +10,12 @@ fn get_block_size() -> u64 {
 #[cfg(target_family = "unix")]
 pub fn get_metadata(d: &DirEntry, use_apparent_size: bool) -> Option<(u64, Option<(u64, u64)>)> {
     use std::os::unix::fs::MetadataExt;
-    d.metadata().ok().and_then(|md| {
+    d.metadata().ok().map(|md| {
         let inode = Some((md.ino(), md.dev()));
         if use_apparent_size {
-            Some((md.len(), inode))
+            (md.len(), inode)
         } else {
-            Some((md.blocks() * get_block_size(), inode))
+            (md.blocks() * get_block_size(), inode)
         }
     })
 }


### PR DESCRIPTION
Fixes a bunch of clippy warnings which includes:
  * Don't box the Nodes (not needed since it's inside a vec)
  * Reversing the node children no longer requires collecting everything into an intermediary vec

Let me know if some of these changes you don't want (specifically the collapsed if-then-else branches you may prefer the original... I just went for cleaning everything for a first pass.