### PR TITLE
Support excluding filesystems with -x

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,12 @@ fn main() {
                 .help("If set sub directories will not have their path shortened"),
         )
         .arg(
+            Arg::with_name("limit_filesystem")
+                .short("x")
+                .long("limit-filesystem")
+                .help("Only count the files and directories in the same filesystem as the supplied directory"),
+        )
+        .arg(
             Arg::with_name("display_apparent_size")
                 .short("s")
                 .long("apparent-size")
@@ -110,9 +116,15 @@ fn main() {
     }
 
     let use_apparent_size = options.is_present("display_apparent_size");
+    let limit_filesystem = options.is_present("limit_filesystem");
 
     let simplified_dirs = simplify_dir_names(target_dirs);
-    let (permissions, nodes) = get_dir_tree(&simplified_dirs, use_apparent_size, threads);
+    let (permissions, nodes) = get_dir_tree(
+        &simplified_dirs,
+        use_apparent_size,
+        limit_filesystem,
+        threads,
+    );
     let sorted_data = sort(nodes);
     let biggest_ones = {
         match depth {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -100,7 +100,7 @@ pub fn get_dir_tree(
 fn get_allowed_filesystems(top_level_names: &HashSet<String>) -> Option<HashSet<u64>> {
     let mut limit_filesystems: HashSet<u64> = HashSet::new();
     for file_name in top_level_names.iter() {
-        if let Some(a) = get_filesystem(file_name) {
+        if let Ok(a) = get_filesystem(file_name) {
             limit_filesystems.insert(a);
         }
     }

--- a/src/utils/platform.rs
+++ b/src/utils/platform.rs
@@ -1,5 +1,6 @@
 use jwalk::DirEntry;
 use std::fs;
+use std::io;
 
 #[cfg(target_family = "unix")]
 fn get_block_size() -> u64 {
@@ -41,20 +42,20 @@ pub fn get_metadata(d: &DirEntry, _apparent: bool) -> Option<(u64, Option<(u64, 
 }
 
 #[cfg(target_family = "unix")]
-pub fn get_filesystem(file_path: &str) -> Option<u64> {
+pub fn get_filesystem(file_path: &str) -> Result<u64, io::Error> {
     use std::os::unix::fs::MetadataExt;
-    let metadata = fs::metadata(file_path).unwrap();
-    Some(metadata.dev())
+    let metadata = fs::metadata(file_path)?;
+    Ok(metadata.dev())
 }
 
 #[cfg(target_family = "windows")]
-pub fn get_device(file_path: &str) -> Option<u64> {
+pub fn get_device(file_path: &str) -> Result<u64, io::Error> {
     use std::os::windows::fs::MetadataExt;
-    let metadata = fs::metadata(file_path).unwrap();
-    Some(metadata.volume_serial_number())
+    let metadata = fs::metadata(file_path)?;
+    Ok(metadata.volume_serial_number())
 }
 
 #[cfg(all(not(target_family = "windows"), not(target_family = "unix")))]
-pub fn get_device(file_path: &str) -> Option<u64> {
+pub fn get_device(file_path: &str) -> Result<u64, io::Error> {
     None
 }


### PR DESCRIPTION
https://github.com/bootandy/dust/issues/50

Add optional -x flag to limit search to the current filesystem.

Add (untested) support for windows for the equivalent of inode and
device.