### PR TITLE
Add option to ignore directories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,13 @@ fn main() {
                 .help("If set sub directories will not have their path shortened"),
         )
         .arg(
+            Arg::with_name("ignore_directory")
+                .short("X")
+                .long("ignore-directory")
+                .takes_value(true)
+                .help("Exclude any file or directory with contains this substring."),
+        )
+        .arg(
             Arg::with_name("limit_filesystem")
                 .short("x")
                 .long("limit-filesystem")
@@ -128,10 +135,12 @@ fn main() {
 
     let use_apparent_size = options.is_present("display_apparent_size");
     let limit_filesystem = options.is_present("limit_filesystem");
+    let ignore_directory = options.value_of("ignore_directory");
 
     let simplified_dirs = simplify_dir_names(target_dirs);
     let (permissions, nodes) = get_dir_tree(
         &simplified_dirs,
+        ignore_directory,
         use_apparent_size,
         limit_filesystem,
         threads,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -299,3 +299,35 @@ fn no_substring_of_names_output() -> String {
     "
     .into()
 }
+
+// Check against directories and files whos names are substrings of each other
+#[test]
+pub fn test_ignore_dir() {
+    assert_cli::Assert::main_binary()
+        .with_args(&["-c", "-X", "dir_substring", "src/test_dir2"])
+        .stdout()
+        .is(ignore_dir_output().as_str())
+        .unwrap();
+}
+
+#[cfg(target_os = "linux")]
+fn ignore_dir_output() -> String {
+    "
+  16K ─┬ test_dir2
+ 8.0K  ├─┬ dir
+ 4.0K  │ └── hello
+ 4.0K  └── dir_name_clash
+    "
+    .into()
+}
+
+#[cfg(target_os = "macos")]
+fn ignore_dir_output() -> String {
+    "
+ 8.0K ─┬ test_dir2
+ 4.0K  ├─┬ dir
+ 4.0K  │ └── hello
+ 4.0K  └── dir_name_clash
+    "
+    .into()
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -70,6 +70,7 @@ pub fn simplify_dir_names(filenames: Vec<&str>) -> HashSet<String> {
 
 pub fn get_dir_tree(
     top_level_names: &HashSet<String>,
+    ignore_directory: Option<&str>,
     apparent_size: bool,
     limit_filesystem: bool,
     threads: Option<usize>,
@@ -88,6 +89,7 @@ pub fn get_dir_tree(
             &b,
             apparent_size,
             &restricted_filesystems,
+            &ignore_directory,
             &mut inodes,
             &mut data,
             &mut permissions,
@@ -118,6 +120,7 @@ fn examine_dir(
     top_dir: &str,
     apparent_size: bool,
     filesystems: &Option<HashSet<u64>>,
+    ignore_directory: &Option<&str>,
     inodes: &mut HashSet<(u64, u64)>,
     data: &mut HashMap<String, u64>,
     file_count_no_permission: &mut u64,
@@ -132,6 +135,14 @@ fn examine_dir(
     for entry in iter {
         if let Ok(e) = entry {
             let maybe_size_and_inode = get_metadata(&e, apparent_size);
+            match ignore_directory {
+                Some(d) => {
+                    if e.path().to_string_lossy().contains(*d) {
+                        continue;
+                    }
+                }
+                _ => {}
+            }
 
             match maybe_size_and_inode {
                 Some((size, maybe_inode)) => {


### PR DESCRIPTION
https://github.com/bootandy/dust/issues/46

Add -X flag used to ignore any file or directory that matches the
provided substring.
This means that -X e will ignore any file or directory with an 'e' in
it.