### PR TITLE
Maybe fix windows 8 support

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,6 @@
 extern crate ansi_term;
 
 use self::ansi_term::Colour::Fixed;
-use self::ansi_term::Style;
 use crate::utils::Node;
 
 use terminal_size::{terminal_size, Height, Width};
@@ -287,16 +286,13 @@ pub fn format_string(
         "".into()
     };
 
-    format!(
-        "{} {}{}",
-        if is_biggest && display_data.colors_on {
-            Fixed(196).paint(pretty_size)
-        } else {
-            Style::new().paint(pretty_size)
-        },
-        tree_and_path,
-        percents,
-    )
+    let pretty_size = if is_biggest && display_data.colors_on {
+        format!("{}", Fixed(196).paint(pretty_size))
+    } else {
+        pretty_size
+    };
+
+    format!("{} {}{}", pretty_size, tree_and_path, percents)
 }
 
 fn human_readable_number(size: u64) -> String {


### PR DESCRIPTION
enable_ansi_support must be run for windows 10 but is not required and
indeed fails if run on windows < 10.

Disable the expect so the code might run on windows 8

may fix:
https://github.com/bootandy/dust/issues/70