### PR TITLE
Maint/CI ~ fix features option for GHA `cargo ...` and `cross ...`

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -32,6 +32,12 @@ jobs:
         case ${{ matrix.job.os }} in windows-latest) unset JOB_DO_FORMAT_TESTING ;; esac;
         echo set-output name=JOB_DO_FORMAT_TESTING::${JOB_DO_FORMAT_TESTING:-<empty>/false}
         echo ::set-output name=JOB_DO_FORMAT_TESTING::${JOB_DO_FORMAT_TESTING}
+        # target-specific options
+        # * CARGO_FEATURES_OPTION
+        CARGO_FEATURES_OPTION='' ;
+        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+        echo set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
+        echo ::set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -50,7 +56,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: ${{ matrix.job.cargo-options }} -- -D warnings
+        args: ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -- -D warnings
 
   min_version:
     name: MinSRV # Minimum supported rust version
@@ -149,6 +155,11 @@ jobs:
         echo set-output name=DEPLOY::${DEPLOY:-<empty>/false}
         echo ::set-output name=DEPLOY::${DEPLOY}
         # target-specific options
+        # * CARGO_FEATURES_OPTION
+        CARGO_FEATURES_OPTION='' ;
+        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+        echo set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
+        echo ::set-output name=CARGO_FEATURES_OPTION::${CARGO_FEATURES_OPTION}
         # * CARGO_USE_CROSS (truthy)
         CARGO_USE_CROSS='true' ; case '${{ matrix.job.use-cross }}' in ''|0|f|false|n|no) unset CARGO_USE_CROSS ;; esac;
         echo set-output name=CARGO_USE_CROSS::${CARGO_USE_CROSS:-<empty>/false}
@@ -193,13 +204,13 @@ jobs:
       with:
         use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
         command: build
-        args: --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} 
+        args: --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
     - name: Test
       uses: actions-rs/cargo@v1
       with:
         use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
         command: test
-        args: --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }}
+        args: --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
     - name: Archive executable artifacts
       uses: actions/upload-artifact@master
       with:


### PR DESCRIPTION
This fixes the failing empty features issue more generically and robustly.

I just noticed the GHA builds were failing on another repo and created this fix. I see that you've fixed it here by removing support for the features option completely. This implementation works whether the build uses features or not. It'll be more robust in the case that you add any features option at a later date.

Since, you're current implementation works, I understand if you don't want to merge this ... but I think that this is a better version which a future you might appreciate. 😄 