### PR TITLE
encode non-printable characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "ignore 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "lscolors 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stfu8 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "thousands 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -326,6 +327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "stfu8"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 "checksum remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+"checksum stfu8 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf70433e3300a3c395d06606a700cdf4205f4f14dbae2c6833127c6bb22db77"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum terminal_size 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ ignore="0.4"
 crossbeam-channel = "0.4"
 walkdir="2.3"
 thousands = "0.2"
+stfu8 = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi-util = "0.1"

--- a/src/display.rs
+++ b/src/display.rs
@@ -9,6 +9,8 @@ use terminal_size::{terminal_size, Height, Width};
 
 use unicode_width::UnicodeWidthStr;
 
+use stfu8::encode_u8;
+
 use std::cmp::max;
 use std::cmp::min;
 use std::fs;
@@ -277,7 +279,7 @@ fn get_printable_name<P: AsRef<Path>>(dir_name: &P, long_paths: bool) -> String 
             dir_name
         }
     };
-    printable_name.display().to_string()
+    encode_u8(printable_name.display().to_string().as_bytes())
 }
 
 fn pad_or_trim_filename(node: &Node, indent: &str, display_data: &DisplayData) -> String {


### PR DESCRIPTION
I tried to use [stfu8](https://crates.io/crates/stfu8) package to encode utf-8 characters.  
Maybe this could resolve issue #118.

p.s. I'm not very familiar with Rust, feel free to abandon this.