### PR TITLE
Be less prescriptive for the ansi_term dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "dust"
 path = "src/main.rs"
 
 [dependencies]
-ansi_term = "=0.12"
+ansi_term = "0.12"
 clap = "=2.33"
 lscolors = "0.7"
 num_cpus = "1"


### PR DESCRIPTION
It makes life of packager harder.
cargo test works with ansi_term 0.12.1