### PR TITLE
bugfix: Fix crash when using '-f' flag

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -125,7 +125,7 @@ pub fn draw_it(
     let root_node = option_root_node.unwrap();
 
     let num_chars_needed_on_left_most = if by_filecount {
-        let max_size = root_node.children.iter().map(|n| n.size).fold(0, max);
+        let max_size = root_node.size;
         max_size.separate_with_commas().chars().count()
     } else {
         5 // Under normal usage we need 5 chars to display the size of a directory


### PR DESCRIPTION
The old code was subtly different in the way the root node worked. This
changed in the v0.6.0 version when dependencies were removed. The code
to handle file count was never updated

https://github.com/bootandy/dust/issues/162