### PR TITLE
Build Debian packages in CI

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -215,7 +215,7 @@ jobs:
       with:
           command: deb
           args: --no-build --target=${{ matrix.job.target }}
-      if: ${{ contains(matrix.job.target, "musl") }}
+      if: ${{ contains(matrix.job.target, 'musl') }}
     - name: Test
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -206,15 +206,16 @@ jobs:
         command: build
         args: --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
     - name: Install cargo-deb
-      uses: action-rs/cargo@v1
+      uses: actions-rs/cargo@v1
       with:
           command: install
           args: cargo-deb
     - name: Build deb
-      uses: action-rs/cargo@v1
+      uses: actions-rs/cargo@v1
       with:
           command: deb
           args: --no-build --target=${{ matrix.job.target }}
+      if: ${{ contains(matrix.job.target, "musl") }}
     - name: Test
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -205,6 +205,16 @@ jobs:
         use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
         command: build
         args: --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+    - name: Install cargo-deb
+      uses: action-rs/cargo@v1
+      with:
+          command: install
+          args: cargo-deb
+    - name: Build deb
+      uses: action-rs/cargo@v1
+      with:
+          command: deb
+          args: --no-build --target=${{ matrix.job.target }}
     - name: Test
       uses: actions-rs/cargo@v1
       with:
@@ -216,6 +226,11 @@ jobs:
       with:
         name: ${{ env.PROJECT_NAME }}-${{ matrix.job.target }}
         path: target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}
+    - name: Archive deb artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: ${{ env.PROJECT_NAME }}-${{ matrix.job.target }}.deb
+        path: target/${{ matrix.job.target }}/debian
     - name: Package
       shell: bash
       run: |

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -210,6 +210,7 @@ jobs:
       with:
           command: install
           args: cargo-deb
+      if: ${{ contains(matrix.job.target, 'musl') }}
     - name: Build deb
       uses: actions-rs/cargo@v1
       with:
@@ -232,6 +233,7 @@ jobs:
       with:
         name: ${{ env.PROJECT_NAME }}-${{ matrix.job.target }}.deb
         path: target/${{ matrix.job.target }}/debian
+      if: ${{ contains(matrix.job.target, 'musl') }}
     - name: Package
       shell: bash
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "A more intuitive version of du"
 version = "0.6.2"
 authors = ["bootandy <bootandy@gmail.com>", "nebkor <code@ardent.nebcorp.com>"]
 edition = "2018"
+readme = "README.md"
 
 documentation = "https://github.com/bootandy/dust"
 homepage = "https://github.com/bootandy/dust"
@@ -40,3 +41,16 @@ tempfile = "=3"
 [[test]]
 name = "integration"
 path = "tests/tests.rs"
+
+[package.metadata.deb]
+section = "utils"
+assets = [
+  ["target/release/dust", "usr/bin/", "755"],
+  ["LICENSE", "usr/share/doc/du-dust/", "644"],
+  ["README.md", "usr/share/doc/du-dust/README", "644"],
+]
+extended-description = """\
+Dust is meant to give you an instant overview of which directories are using
+disk space without requiring sort or head. Dust will print a maximum of one
+'Did not have permissions message'.
+"""


### PR DESCRIPTION
Hi! I recently made [an apt repo for Rust cli tools](https://apt.cli.rs/) and I'm interested in adding your tool to the apt repo, because I quite like dust :) I generally would like to download the deb packages directly from your releases, so I don't have to build them myself and everyone can use them as well.

Below is an experimental workflow change that should build debian packages which should statically link against musl so there are no glibc version incompatibilities.