### PR TITLE
Add support for specifying multiple filters

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,7 @@
-use crate::platform::get_metadata;
-use crate::utils::is_filtered_out_due_to_invert_regex;
-use crate::utils::is_filtered_out_due_to_regex;
+use crate::{
+    platform::get_metadata,
+    utils::{file_matches_all_regexes, file_matches_any_regexes},
+};
 
 use regex::Regex;
 use std::cmp::Ordering;
@@ -18,8 +19,8 @@ pub struct Node {
 pub fn build_node(
     dir: PathBuf,
     children: Vec<Node>,
-    filter_regex: &Option<Regex>,
-    invert_filter_regex: &Option<Regex>,
+    filter_regexes: &Vec<Regex>,
+    invert_filter_regexes: &Vec<Regex>,
     use_apparent_size: bool,
     is_symlink: bool,
     is_file: bool,
@@ -33,8 +34,10 @@ pub fn build_node(
                 data.1
             };
 
-            let size = if is_filtered_out_due_to_regex(filter_regex, &dir)
-                || is_filtered_out_due_to_invert_regex(invert_filter_regex, &dir)
+            let size = if (filter_regexes.len() > 0
+                && !file_matches_all_regexes(filter_regexes, &dir))
+                || (invert_filter_regexes.len() > 0
+                    && file_matches_any_regexes(invert_filter_regexes, &dir))
                 || (is_symlink && !use_apparent_size)
                 || by_filecount && !is_file
             {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -57,18 +57,31 @@ pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
     path.as_ref().components().collect::<PathBuf>()
 }
 
-pub fn is_filtered_out_due_to_regex(filter_regex: &Option<Regex>, dir: &Path) -> bool {
-    match filter_regex {
-        Some(fr) => !fr.is_match(&dir.as_os_str().to_string_lossy()),
-        None => false,
+pub fn file_matches_any_regexes(regexes: &Vec<Regex>, dir: &Path) -> bool {
+    if regexes.len() == 0 {
+        return true;
     }
-}
 
-pub fn is_filtered_out_due_to_invert_regex(filter_regex: &Option<Regex>, dir: &Path) -> bool {
-    match filter_regex {
-        Some(fr) => fr.is_match(&dir.as_os_str().to_string_lossy()),
-        None => false,
+    let dir_as_str = dir.as_os_str().to_string_lossy();
+    for fr in regexes {
+        if fr.is_match(&dir_as_str) {
+            return true;
+        }
     }
+    return false;
+}
+pub fn file_matches_all_regexes(regexes: &Vec<Regex>, dir: &Path) -> bool {
+    if regexes.len() == 0 {
+        return true;
+    }
+
+    let dir_as_str = dir.as_os_str().to_string_lossy();
+    for fr in regexes {
+        if !fr.is_match(&dir_as_str) {
+            return false;
+        }
+    }
+    return true;
 }
 
 fn is_a_parent_of<P: AsRef<Path>>(parent: P, child: P) -> bool {

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -139,6 +139,16 @@ pub fn test_show_files_by_regex() {
     // Check there are no files named: '.match_nothing' in the tests directory
     let output = build_command(vec!["-c", "-e", "match_nothing$", "tests"]);
     assert!(output.contains("0B ┌── tests"));
+
+    // when filtering for test_dir, we'll have test_dir2 and test_dir
+    let output = build_command(vec!["-c", "-e", "test_dir", "tests"]);
+    assert!(output.contains("test_dir\n"));
+    assert!(output.contains("test_dir2\n"));
+
+    // when filtering for test_dir and 2, we'll have test_dir2 but not test_dir
+    let output = build_command(vec!["-c", "-e", "test_dir", "-e", "2", "tests"]);
+    assert!(!output.contains("test_dir\n"));
+    assert!(output.contains("test_dir2\n"));
 }
 
 #[test]
@@ -150,6 +160,10 @@ pub fn test_show_files_by_invert_regex() {
     let output = build_command(vec!["-c", "-f", "-v", "a", "tests/test_dir2"]);
     // There are 2 files without 'a' in the name
     assert!(output.contains("2 ┌─┴ test_dir2"));
+
+    let output = build_command(vec!["-c", "-f", "-v", "a", "-v", "n", "tests/test_dir2"]);
+    // There is only 1 file without 'a' or 'n' in the name
+    assert!(output.contains("1 ┌─┴ test_dir2"));
 
     // There are 4 files in the test_dir2 hierarchy
     let output = build_command(vec!["-c", "-f", "-v", "match_nothing$", "tests/test_dir2"]);


### PR DESCRIPTION
 The current code would only use the first provided filter/exclusion filter.

 For filters, it will only return paths that match all the filters, and for exclusions it will only return paths that match none of the filters.

This is a proposed fix for #188. I tried to keep similar performance characteristics when only one element is provided, by matching up the regexes via their length to mirror the `Some`/`None` approach.

Here the idea is to hold onto the filters as a list and then check for them. I think there's an even more performant strategy of basically building a single regex out of all of these, but I'm not super confident in my regex-building skills to do the escaping right.