### PR TITLE
docs(readme): add pacstall installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Because I want an easy way to see where my disk is being used.
 
 * `brew tap tgotwig/linux-dust && brew install dust`
 
+#### [Pacstall](https://github.com/pacstall/pacstall) (Debian/Ubuntu)
+
+* `pacstall -I dust-bin`
+
 #### Windows:
 * Windows GNU version - works
 * Windows MSVC - requires: VCRUNTIME140.dll


### PR DESCRIPTION
Adds pacstall as an installation method for Debian/Ubuntu users as requested here: https://github.com/bootandy/dust/issues/202#issuecomment-997851337