### PR TITLE
Fix: Allow -n to be used with -d

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -69,19 +69,19 @@ pub fn get_all_file_types(top_level_nodes: Vec<Node>, n: usize) -> Option<Displa
 
 fn add_children<'a>(
     using_a_filter: bool,
-    line: &'a Node,
+    file_or_folder: &'a Node,
     depth: usize,
     mut heap: BinaryHeap<&'a Node>,
 ) -> BinaryHeap<&'a Node> {
-    if depth > line.depth {
+    if depth > file_or_folder.depth {
         if using_a_filter {
-            line.children.iter().for_each(|c| {
+            file_or_folder.children.iter().for_each(|c| {
                 if c.name.is_file() || c.size > 0 {
                     heap.push(c)
                 }
             });
         } else {
-            line.children.iter().for_each(|c| heap.push(c));
+            file_or_folder.children.iter().for_each(|c| heap.push(c));
         }
     }
     heap

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,6 +12,7 @@ pub struct Node {
     pub size: u64,
     pub children: Vec<Node>,
     pub inode_device: Option<(u64, u64)>,
+    pub depth: usize,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -24,6 +25,7 @@ pub fn build_node(
     is_symlink: bool,
     is_file: bool,
     by_filecount: bool,
+    depth: usize,
 ) -> Option<Node> {
     match get_metadata(&dir, use_apparent_size) {
         Some(data) => {
@@ -50,6 +52,7 @@ pub fn build_node(
                 size,
                 children,
                 inode_device,
+                depth,
             })
         }
         None => None,


### PR DESCRIPTION
Allow -n for number_of_lines to be used with -d 'max depth'

Remove depth specific functions, the job is now handled by the mainline

Add depth as a field onto the Node object.

https://github.com/bootandy/dust/issues/220
