### PR TITLE
Lots of code cleanup

### DIFF
--- a/src/display_node.rs
+++ b/src/display_node.rs
@@ -1,33 +1,11 @@
-use std::cmp::Ordering;
 use std::path::PathBuf;
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct DisplayNode {
-    pub name: PathBuf, //todo: consider moving to a string?
+    // Note: the order of fields in important here, for PartialEq and PartialOrd
     pub size: u64,
+    pub name: PathBuf, //todo: consider moving to a string?
     pub children: Vec<DisplayNode>,
-}
-
-impl Ord for DisplayNode {
-    fn cmp(&self, other: &Self) -> Ordering {
-        if self.size == other.size {
-            self.name.cmp(&other.name)
-        } else {
-            self.size.cmp(&other.size)
-        }
-    }
-}
-
-impl PartialOrd for DisplayNode {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for DisplayNode {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.size == other.size && self.children == other.children
-    }
 }
 
 impl DisplayNode {
@@ -35,12 +13,12 @@ impl DisplayNode {
         self.children.len() as u64
     }
 
-    pub fn get_children_from_node(&self, is_reversed: bool) -> impl Iterator<Item = DisplayNode> {
+    pub fn get_children_from_node(&self, is_reversed: bool) -> impl Iterator<Item = &DisplayNode> {
         // we box to avoid the clippy lint warning
-        let out: Box<dyn Iterator<Item = DisplayNode>> = if is_reversed {
-            Box::new(self.children.clone().into_iter().rev())
+        let out: Box<dyn Iterator<Item = &DisplayNode>> = if is_reversed {
+            Box::new(self.children.iter().rev())
         } else {
-            Box::new(self.children.clone().into_iter())
+            Box::new(self.children.iter())
         };
         out
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -127,7 +127,7 @@ fn build_by_all_file_types<'a>(
 }
 
 fn get_new_root(top_level_nodes: Vec<Node>) -> Node {
-    if top_level_nodes.len() > 1 {
+    if top_level_nodes.len() != 1 {
         Node {
             name: PathBuf::from("(total)"),
             size: top_level_nodes.iter().map(|node| node.size).sum(),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,6 +3,8 @@ use crate::node::Node;
 use std::collections::BinaryHeap;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::path::Path;
 use std::path::PathBuf;
 
 pub fn get_biggest(
@@ -21,14 +23,14 @@ pub fn get_biggest(
     let root = get_new_root(top_level_nodes);
     let mut allowed_nodes = HashSet::new();
 
-    allowed_nodes.insert(&root.name);
+    allowed_nodes.insert(root.name.as_path());
     heap = add_children(using_a_filter, &root, depth, heap);
 
     for _ in number_top_level_nodes..n {
         let line = heap.pop();
         match line {
             Some(line) => {
-                allowed_nodes.insert(&line.name);
+                allowed_nodes.insert(line.name.as_path());
                 heap = add_children(using_a_filter, line, depth, heap);
             }
             None => break,
@@ -37,33 +39,59 @@ pub fn get_biggest(
     recursive_rebuilder(&allowed_nodes, &root)
 }
 
-pub fn get_all_file_types(top_level_nodes: Vec<Node>, n: usize) -> Option<DisplayNode> {
-    let mut map: HashMap<String, DisplayNode> = HashMap::new();
-    build_by_all_file_types(top_level_nodes, &mut map);
-    let mut by_types: Vec<DisplayNode> = map.into_iter().map(|(_k, v)| v).collect();
-    by_types.sort();
-    by_types.reverse();
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct ExtensionNode<'a> {
+    size: u64,
+    extension: Option<&'a OsStr>,
+}
 
-    let displayed = if by_types.len() <= n {
-        by_types
-    } else {
-        let (displayed, rest) = by_types.split_at(if n > 1 { n - 1 } else { 1 });
-        let remaining = DisplayNode {
-            name: PathBuf::from("(others)"),
-            size: rest.iter().map(|a| a.size).sum(),
-            children: vec![],
-        };
+pub fn get_all_file_types(top_level_nodes: &[Node], n: usize) -> Option<DisplayNode> {
+    let ext_nodes = {
+        let mut extension_cumulative_sizes = HashMap::new();
+        build_by_all_file_types(top_level_nodes, &mut extension_cumulative_sizes);
 
-        let mut displayed = displayed.to_vec();
-        displayed.push(remaining);
-        displayed
+        let mut extension_cumulative_sizes: Vec<ExtensionNode<'_>> = extension_cumulative_sizes
+            .iter()
+            .map(|(&extension, &size)| ExtensionNode { extension, size })
+            .collect();
+
+        extension_cumulative_sizes.sort_by(|lhs, rhs| lhs.cmp(rhs).reverse());
+
+        extension_cumulative_sizes
     };
+
+    let mut ext_nodes_iter = ext_nodes.iter();
+
+    // First, collect the first N - 1 nodes...
+    let mut displayed: Vec<DisplayNode> = ext_nodes_iter
+        .by_ref()
+        .take(if n > 1 { n - 1 } else { 1 })
+        .map(|node| DisplayNode {
+            name: PathBuf::from(
+                node.extension
+                    .map(|ext| format!(".{}", ext.to_string_lossy()))
+                    .unwrap_or_else(|| "(no extension)".to_owned()),
+            ),
+            size: node.size,
+            children: vec![],
+        })
+        .collect();
+
+    // ...then, aggregate the remaining nodes (if any) into a single  "(others)" node
+    if ext_nodes_iter.len() > 0 {
+        displayed.push(DisplayNode {
+            name: PathBuf::from("(others)"),
+            size: ext_nodes_iter.map(|node| node.size).sum(),
+            children: vec![],
+        });
+    }
 
     let result = DisplayNode {
         name: PathBuf::from("(total)"),
-        size: displayed.iter().map(|a| a.size).sum(),
+        size: displayed.iter().map(|node| node.size).sum(),
         children: displayed,
     };
+
     Some(result)
 }
 
@@ -74,44 +102,35 @@ fn add_children<'a>(
     mut heap: BinaryHeap<&'a Node>,
 ) -> BinaryHeap<&'a Node> {
     if depth > file_or_folder.depth {
-        if using_a_filter {
-            file_or_folder.children.iter().for_each(|c| {
-                if c.name.is_file() || c.size > 0 {
-                    heap.push(c)
-                }
-            });
-        } else {
-            file_or_folder.children.iter().for_each(|c| heap.push(c));
-        }
+        heap.extend(
+            file_or_folder
+                .children
+                .iter()
+                .filter(|c| !using_a_filter || c.name.is_file() || c.size > 0),
+        )
     }
     heap
 }
 
-fn build_by_all_file_types(top_level_nodes: Vec<Node>, counter: &mut HashMap<String, DisplayNode>) {
+fn build_by_all_file_types<'a>(
+    top_level_nodes: &'a [Node],
+    counter: &mut HashMap<Option<&'a OsStr>, u64>,
+) {
     for node in top_level_nodes {
         if node.name.is_file() {
             let ext = node.name.extension();
-            let key: String = match ext {
-                Some(e) => ".".to_string() + &e.to_string_lossy(),
-                None => "(no extension)".into(),
-            };
-            let mut display_node = counter.entry(key.clone()).or_insert(DisplayNode {
-                name: PathBuf::from(key),
-                size: 0,
-                children: vec![],
-            });
-            display_node.size += node.size;
+            let cumulative_size = counter.entry(ext).or_default();
+            *cumulative_size += node.size;
         }
-        build_by_all_file_types(node.children, counter)
+        build_by_all_file_types(&node.children, counter)
     }
 }
 
 fn get_new_root(top_level_nodes: Vec<Node>) -> Node {
     if top_level_nodes.len() > 1 {
-        let total_size = top_level_nodes.iter().map(|node| node.size).sum();
         Node {
             name: PathBuf::from("(total)"),
-            size: total_size,
+            size: top_level_nodes.iter().map(|node| node.size).sum(),
             children: top_level_nodes,
             inode_device: None,
             depth: 0,
@@ -121,27 +140,19 @@ fn get_new_root(top_level_nodes: Vec<Node>) -> Node {
     }
 }
 
-fn recursive_rebuilder<'a>(
-    allowed_nodes: &'a HashSet<&PathBuf>,
-    current: &Node,
-) -> Option<DisplayNode> {
+fn recursive_rebuilder(allowed_nodes: &HashSet<&Path>, current: &Node) -> Option<DisplayNode> {
     let mut new_children: Vec<_> = current
         .children
         .iter()
-        .filter_map(|c| {
-            if allowed_nodes.contains(&c.name) {
-                recursive_rebuilder(allowed_nodes, c)
-            } else {
-                None
-            }
-        })
+        .filter(|c| allowed_nodes.contains(c.name.as_path()))
+        .filter_map(|c| recursive_rebuilder(allowed_nodes, c))
         .collect();
-    new_children.sort();
-    new_children.reverse();
-    let newnode = DisplayNode {
+
+    new_children.sort_by(|lhs, rhs| lhs.cmp(rhs).reverse());
+
+    Some(DisplayNode {
         name: current.name.clone(),
         size: current.size,
         children: new_children,
-    };
-    Some(newnode)
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ static DEFAULT_TERMINAL_WIDTH: usize = 80;
 /// `ansi_term::enable_ansi_support` only exists on Windows; this wrapper
 /// function makes it available on all platforms
 #[inline]
-fn enable_ansi_support() -> Result<(), i32> {
+fn enable_ansi_support() -> Result<(), u32> {
     #[cfg(windows)]
     {
         ansi_term::enable_ansi_support()

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 #[cfg(target_family = "unix")]
 fn get_block_size() -> u64 {
-    // All os specific implementations of MetatdataExt seem to define a block as 512 bytes
+    // All os specific implementations of MetadataExt seem to define a block as 512 bytes
     // https://doc.rust-lang.org/std/os/linux/fs/trait.MetadataExt.html#tymethod.st_blocks
     512
 }
@@ -105,12 +105,12 @@ pub fn get_metadata(d: &Path, _use_apparent_size: bool) -> Option<(u64, Option<(
     use std::os::windows::fs::MetadataExt;
     match d.metadata() {
         Ok(ref md) => {
-            const FILE_ATTRIBUTE_ARCHIVE: u32 = 0x20u32;
-            const FILE_ATTRIBUTE_READONLY: u32 = 0x1u32;
-            const FILE_ATTRIBUTE_HIDDEN: u32 = 0x2u32;
-            const FILE_ATTRIBUTE_SYSTEM: u32 = 0x4u32;
-            const FILE_ATTRIBUTE_NORMAL: u32 = 0x80u32;
-            const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10u32;
+            const FILE_ATTRIBUTE_ARCHIVE: u32 = 0x20;
+            const FILE_ATTRIBUTE_READONLY: u32 = 0x01;
+            const FILE_ATTRIBUTE_HIDDEN: u32 = 0x02;
+            const FILE_ATTRIBUTE_SYSTEM: u32 = 0x04;
+            const FILE_ATTRIBUTE_NORMAL: u32 = 0x80;
+            const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10;
 
             let attr_filtered = md.file_attributes()
                 & !(FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_SYSTEM);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,7 @@ use regex::Regex;
 
 pub fn simplify_dir_names<P: AsRef<Path>>(filenames: Vec<P>) -> HashSet<PathBuf> {
     let mut top_level_names: HashSet<PathBuf> = HashSet::with_capacity(filenames.len());
+
     for t in filenames {
         let top_level_name = normalize_path(t);
         let mut can_add = true;
@@ -26,6 +27,7 @@ pub fn simplify_dir_names<P: AsRef<Path>>(filenames: Vec<P>) -> HashSet<PathBuf>
             top_level_names.insert(top_level_name);
         }
     }
+
     top_level_names
 }
 
@@ -33,14 +35,9 @@ pub fn get_filesystem_devices<'a, P: IntoIterator<Item = &'a PathBuf>>(paths: P)
     // Gets the device ids for the filesystems which are used by the argument paths
     paths
         .into_iter()
-        .filter_map(|p| {
-            let meta = get_metadata(p, false);
-
-            if let Some((_size, Some((_id, dev)))) = meta {
-                Some(dev)
-            } else {
-                None
-            }
+        .filter_map(|p| match get_metadata(p, false) {
+            Some((_size, Some((_id, dev)))) => Some(dev),
+            _ => None,
         })
         .collect()
 }
@@ -52,7 +49,7 @@ pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
     // 3. removing trailing extra separators and '.' ("current directory") path segments
     // * `Path.components()` does all the above work; ref: <https://doc.rust-lang.org/std/path/struct.Path.html#method.components>
     // 4. changing to os preferred separator (automatically done by recollecting components back into a PathBuf)
-    path.as_ref().components().collect::<PathBuf>()
+    path.as_ref().components().collect()
 }
 
 pub fn is_filtered_out_due_to_regex(filter_regex: &[Regex], dir: &Path) -> bool {

--- a/tests/test_exact_output.rs
+++ b/tests/test_exact_output.rs
@@ -20,14 +20,11 @@ fn copy_test_data(dir: &str) {
     // First remove the existing directory - just incase it is there and has incorrect data
     let last_slash = dir.rfind('/').unwrap();
     let last_part_of_dir = dir.chars().skip(last_slash).collect::<String>();
-    match Command::new("rm")
+    let _ = Command::new("rm")
         .arg("-rf")
         .arg("/tmp/".to_owned() + &*last_part_of_dir)
-        .ok()
-    {
-        Ok(_) => {}
-        Err(_) => {}
-    };
+        .ok();
+
     match Command::new("cp").arg("-r").arg(dir).arg("/tmp/").ok() {
         Ok(_) => {}
         Err(err) => {
@@ -48,14 +45,14 @@ fn exact_output_test<T: AsRef<OsStr>>(valid_outputs: Vec<String>, command_args: 
     initialize();
 
     let mut a = &mut Command::cargo_bin("dust").unwrap();
+
     for p in command_args {
         a = a.arg(p);
     }
-    let output: String = str::from_utf8(&a.unwrap().stdout).unwrap().into();
 
-    assert!(valid_outputs
-        .iter()
-        .fold(false, |sum, i| sum || output.contains(i)));
+    let output = str::from_utf8(&a.unwrap().stdout).unwrap().to_owned();
+
+    assert!(valid_outputs.iter().any(|i| output.contains(i)));
 }
 
 // "windows" result data can vary by host (size seems to be variable by one byte); fix code vs test and re-enable
@@ -129,7 +126,7 @@ fn main_output_long_paths() -> Vec<String> {
     vec![mac_and_some_linux, ubuntu]
 }
 
-// Check against directories and files whos names are substrings of each other
+// Check against directories and files whose names are substrings of each other
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
 pub fn test_substring_of_names_and_long_names() {

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -67,7 +67,7 @@ pub fn test_d_flag_works_and_still_recurses_down() {
     assert!(output.contains("4 ┌─┴ test_dir2"));
 }
 
-// Check against directories and files whos names are substrings of each other
+// Check against directories and files whose names are substrings of each other
 #[test]
 pub fn test_ignore_dir() {
     let output = build_command(vec!["-c", "-X", "dir_substring", "tests/test_dir2/"]);

--- a/tests/tests_symlinks.rs
+++ b/tests/tests_symlinks.rs
@@ -39,9 +39,12 @@ pub fn test_soft_sym_link() {
     let a = format!("─┴ {}", dir_s);
 
     let mut cmd = Command::cargo_bin("dust").unwrap();
-    // Mac test runners create long filenames in tmp directories
     let output = cmd
-        .args(["-p", "-c", "-s", "-w 999", dir_s])
+        .arg("-p")
+        .arg("-c")
+        .arg("-s")
+        .args(["-w", "999"])
+        .arg(dir_s)
         .unwrap()
         .stdout;
 
@@ -72,8 +75,13 @@ pub fn test_hard_sym_link() {
     let dirs_output = format!("─┴ {}", dir_s);
 
     let mut cmd = Command::cargo_bin("dust").unwrap();
-    // Mac test runners create long filenames in tmp directories
-    let output = cmd.args(["-p", "-c", "-w 999", dir_s]).unwrap().stdout;
+    let output = cmd
+        .arg("-p")
+        .arg("-c")
+        .args(["-w", "999"])
+        .arg(dir_s)
+        .unwrap()
+        .stdout;
 
     // The link should not appear in the output because multiple inodes are now ordered
     // then filtered.


### PR DESCRIPTION
- Try to use iterator adapters and collect in various places, where possible. This especially benefits `draw_it`.
- Try to use `.map` and other similar methods on `Option`s and `Result`s, where possible
- Replaced nearly all `clone`s with reference-based equivalents
- Summarizing nodes by file extension is now much more efficient (significantly fewer allocations)
- `PartialOrd` and `PartialEq` implementations on `Node` and `DisplayNode` now agree with each other (it's no longer possible to construct a `Node` for which `node1 != node2 && !(node1 < node2) && !(node1 > node2)`).
- Replace `#[cfg(...)]` function definitions with simpler if `cfg!(...)` equivalents
    - The optimized code is the same and this reduces maintenance burden of keeping signatures synchronized
- Simplify CLI `Values` handling by taking advantage of Values::default
- Various spelling corrections in comments
- Replace (`sort`, `reverse`) with `sort_by`

I can split this into several PRs if you'd like, but each change was so small that it was easier to put them all together.