### PR TITLE
Feature: Add skip-total flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,11 @@ fn main() {
                 .help("No percent bars or percentages will be displayed"),
         )
         .arg(
+            Arg::new("skip_total")
+                .long("skip-total")
+                .help("No total row will be displayed"),
+        )
+        .arg(
             Arg::new("by_filecount")
                 .short('f')
                 .long("filecount")
@@ -330,6 +335,7 @@ fn main() {
             by_filecount,
             root_node,
             options.is_present("iso"),
+            options.is_present("skip_total"),
         ),
     }
 }

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -113,6 +113,17 @@ pub fn test_show_files_by_type() {
 }
 
 #[test]
+pub fn test_output_skip_total() {
+    let output = build_command(vec![
+        "--skip-total",
+        "tests/test_dir/many/hello_file",
+        "tests/test_dir/many/a_file",
+    ]);
+    assert!(output.contains("hello_file"));
+    assert!(!output.contains("(total)"));
+}
+
+#[test]
 pub fn test_show_files_by_regex_match_lots() {
     // Check we can see '.rs' files in the tests directory
     let output = build_command(vec!["-c", "-e", "\\.rs$", "tests"]);


### PR DESCRIPTION
Flag to not include the last line containing totals of the output tree

resolves: https://github.com/bootandy/dust/issues/216