### PR TITLE
Fix: Permissions

### DIFF
--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -170,7 +170,10 @@ fn walk(
             })
             .collect();
     } else {
-        permissions_flag.store(true, atomic::Ordering::Relaxed);
+        // Handle edge case where dust is called with a file instead of a directory
+        if !dir.exists() {
+            permissions_flag.store(true, atomic::Ordering::Relaxed);
+        }
     }
     build_node(
         dir,

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -9,11 +9,15 @@ use std::str;
  */
 
 fn build_command<T: AsRef<OsStr>>(command_args: Vec<T>) -> String {
-    let mut a = &mut Command::cargo_bin("dust").unwrap();
+    let mut cmd = &mut Command::cargo_bin("dust").unwrap();
     for p in command_args {
-        a = a.arg(p);
+        cmd = cmd.arg(p);
     }
-    str::from_utf8(&a.unwrap().stdout).unwrap().into()
+    let finished = &cmd.unwrap();
+    let stderr = str::from_utf8(&finished.stderr).unwrap();
+    assert_eq!(stderr, "");
+
+    str::from_utf8(&finished.stdout).unwrap().into()
 }
 
 // We can at least test the file names are there


### PR DESCRIPTION
Stop incorrect reporting of "Did not have permissions" this would
happen where dust is called with a file instead of a directory.

https://github.com/bootandy/dust/issues/241

