### PR TITLE
Cleanup previous PR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,8 +6,7 @@ include!("src/cli.rs");
 fn main() -> Result<(), Error> {
     let outdir = "completions";
     let app_name = "dust";
-    let max_depth = usize::MAX.to_string();
-    let mut cmd = build_cli(&max_depth);
+    let mut cmd = build_cli();
 
     generate_to(Bash, &mut cmd, app_name, outdir)?;
     generate_to(Zsh, &mut cmd, app_name, outdir)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use clap::{Arg, Command};
 
-pub fn build_cli(max_depth: &str) -> Command {
+pub fn build_cli() -> Command<'static> {
     Command::new("Dust")
         .about("Like du but more intuitive")
         .version(env!("CARGO_PKG_VERSION"))
@@ -11,7 +11,6 @@ pub fn build_cli(max_depth: &str) -> Command {
                 .long("depth")
                 .help("Depth to show")
                 .takes_value(true)
-                .default_value(max_depth)
         )
         .arg(
             Arg::new("number_of_lines")

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ fn get_regex_value(maybe_value: Option<Values>) -> Vec<Regex> {
 }
 
 fn main() {
-    let options = build_cli(&usize::MAX.to_string()).get_matches();
+    let options = build_cli().get_matches();
 
     let config = get_config();
 
@@ -108,10 +108,7 @@ fn main() {
         .value_of_t("width")
         .unwrap_or_else(|_| get_width_of_terminal());
 
-    let depth = options.value_of_t("depth").unwrap_or_else(|_| {
-        eprintln!("Ignoring bad value for depth");
-        usize::MAX
-    });
+    let depth = options.value_of_t("depth").unwrap_or(usize::MAX);
 
     // If depth is set, then we set the default number_of_lines to be max
     // instead of screen height


### PR DESCRIPTION
 Dislike the idea of passing a string into build_cli. By removing a call to default_value we can side-step the problem.
    
