### PR TITLE
Allow reading `inputs` from stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ version = "0.8.3"
 dependencies = [
  "ansi_term",
  "assert_cmd",
+ "atty",
  "clap",
  "clap_complete",
  "config-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ strip = true
 
 [dependencies]
 ansi_term = "0.12"
+atty = "0.2.14"
 clap = "3.2.17"
 lscolors = "0.7"
 terminal_size = "0.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,5 +131,5 @@ pub fn build_cli() -> Command<'static> {
                 .long("si")
                 .help("print sizes in powers of 1000 (e.g., 1.1G)")
         )
-        .arg(Arg::new("inputs").multiple_occurrences(true).default_value("."))
+        .arg(Arg::new("inputs").multiple_occurrences(true))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod utils;
 
 use crate::cli::build_cli;
 use std::collections::HashSet;
+use std::io::BufRead;
 use std::process;
 use sysinfo::{System, SystemExt};
 
@@ -91,14 +92,28 @@ fn get_regex_value(maybe_value: Option<Values>) -> Vec<Regex> {
         .collect()
 }
 
+// Returns a list of lines from stdin or `None` if there's nothing to read
+fn get_lines_from_stdin() -> Option<Vec<String>> {
+    atty::isnt(atty::Stream::Stdin).then(|| {
+        std::io::stdin()
+            .lock()
+            .lines()
+            .collect::<Result<_, _>>()
+            .expect("Error reading from stdin")
+    })
+}
+
 fn main() {
     let options = build_cli().get_matches();
     let config = get_config();
+    let stdin_lines = get_lines_from_stdin();
 
-    let target_dirs = options
-        .values_of("inputs")
-        .expect("Should be a default value here")
-        .collect();
+    let target_dirs = match options.values_of("inputs") {
+        Some(values) => values.collect(),
+        None => stdin_lines.as_ref().map_or(vec!["."], |lines| {
+            lines.iter().map(String::as_str).collect()
+        }),
+    };
 
     let summarize_file_types = options.is_present("types");
 


### PR DESCRIPTION
Sometimes it's nice to run `dust` on a list of files/directories generated programmatically with something like `fd` or read from a file. This PR allows users to do just that:

```shell
$ fd ... | dust
$ dust < list_of_directories.txt
```