### PR TITLE
docs: added deb-get as installation source

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Because I want an easy way to see where my disk is being used.
 
 - `pacstall -I dust-bin`
 
+#### [deb-get](https://github.com/wimpysworld/deb-get) (Debian/Ubuntu)
+
+- `deb-get install du-dust`
+
 #### Windows:
 
 - Windows GNU version - works


### PR DESCRIPTION
 [deb-get](https://github.com/wimpysworld/deb-get) allows Ubuntu- and Debian-derived distro users to track and maintain `.deb` packages published authoritatively in 3rd-party apt repos, web sites, `ppa`s and Github releases.
 
That project is running a [mini-event](https://github.com/wimpysworld/deb-get/issues/579) to spread the word to users of supported projects and to encourage new contributors to reach out to supported projects.

This is submitted in the hope that it might be useful to you and your users.  As I haven't begun to learn rust it is likely to be the only contribution I can offer, but it comes with my thanks for your work on `dust`.  
Thanks.
