### PR TITLE
Links2 add support for -L 

### DIFF
--- a/completions/_dust
+++ b/completions/_dust
@@ -35,6 +35,8 @@ _dust() {
 '--version[Print version information]' \
 '-p[Subdirectories will not have their path shortened]' \
 '--full-paths[Subdirectories will not have their path shortened]' \
+'-L[dereference sym links - Treat sym links as directories and go into them]' \
+'--dereference-links[dereference sym links - Treat sym links as directories and go into them]' \
 '-x[Only count the files and directories on the same filesystem as the supplied directory]' \
 '--limit-filesystem[Only count the files and directories on the same filesystem as the supplied directory]' \
 '-s[Use file length instead of blocks]' \

--- a/completions/_dust.ps1
+++ b/completions/_dust.ps1
@@ -41,6 +41,8 @@ Register-ArgumentCompleter -Native -CommandName 'dust' -ScriptBlock {
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Subdirectories will not have their path shortened')
             [CompletionResult]::new('--full-paths', 'full-paths', [CompletionResultType]::ParameterName, 'Subdirectories will not have their path shortened')
+            [CompletionResult]::new('-L', 'L', [CompletionResultType]::ParameterName, 'dereference sym links - Treat sym links as directories and go into them')
+            [CompletionResult]::new('--dereference-links', 'dereference-links', [CompletionResultType]::ParameterName, 'dereference sym links - Treat sym links as directories and go into them')
             [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'Only count the files and directories on the same filesystem as the supplied directory')
             [CompletionResult]::new('--limit-filesystem', 'limit-filesystem', [CompletionResultType]::ParameterName, 'Only count the files and directories on the same filesystem as the supplied directory')
             [CompletionResult]::new('-s', 's', [CompletionResultType]::ParameterName, 'Use file length instead of blocks')

--- a/completions/dust.bash
+++ b/completions/dust.bash
@@ -19,7 +19,7 @@ _dust() {
 
     case "${cmd}" in
         dust)
-            opts="-h -V -d -n -p -X -x -s -r -c -b -z -f -i -v -e -t -w -H -D --help --version --depth --number-of-lines --full-paths --ignore-directory --limit-filesystem --apparent-size --reverse --no-colors --no-percent-bars --min-size --skip-total --filecount --ignore_hidden --invert-filter --filter --file_types --terminal_width --si --only-dir <inputs>..."
+            opts="-h -V -d -n -p -X -L -x -s -r -c -b -z -f -i -v -e -t -w -H -D --help --version --depth --number-of-lines --full-paths --ignore-directory --dereference-links --limit-filesystem --apparent-size --reverse --no-colors --no-percent-bars --min-size --skip-total --filecount --ignore_hidden --invert-filter --filter --file_types --terminal_width --si --only-dir <inputs>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/dust.elv
+++ b/completions/dust.elv
@@ -38,6 +38,8 @@ set edit:completion:arg-completer[dust] = {|@words|
             cand --version 'Print version information'
             cand -p 'Subdirectories will not have their path shortened'
             cand --full-paths 'Subdirectories will not have their path shortened'
+            cand -L 'dereference sym links - Treat sym links as directories and go into them'
+            cand --dereference-links 'dereference sym links - Treat sym links as directories and go into them'
             cand -x 'Only count the files and directories on the same filesystem as the supplied directory'
             cand --limit-filesystem 'Only count the files and directories on the same filesystem as the supplied directory'
             cand -s 'Use file length instead of blocks'

--- a/completions/dust.fish
+++ b/completions/dust.fish
@@ -8,6 +8,7 @@ complete -c dust -s w -l terminal_width -d 'Specify width of output overriding t
 complete -c dust -s h -l help -d 'Print help information'
 complete -c dust -s V -l version -d 'Print version information'
 complete -c dust -s p -l full-paths -d 'Subdirectories will not have their path shortened'
+complete -c dust -s L -l dereference-links -d 'dereference sym links - Treat sym links as directories and go into them'
 complete -c dust -s x -l limit-filesystem -d 'Only count the files and directories on the same filesystem as the supplied directory'
 complete -c dust -s s -l apparent-size -d 'Use file length instead of blocks'
 complete -c dust -s r -l reverse -d 'Print tree upside down (biggest highest)'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,12 @@ pub fn build_cli() -> Command<'static> {
                 .multiple_occurrences(true)
                 .help("Exclude any file or directory with this name"),
         )
+         .arg(
+            Arg::new("dereference_links")
+                .short('L')
+                .long("dereference-links")
+                .help("dereference sym links - Treat sym links as directories and go into them"),
+        )
         .arg(
             Arg::new("limit_filesystem")
                 .short('x')
@@ -136,6 +142,6 @@ pub fn build_cli() -> Command<'static> {
             Arg::new("only_dir")
                 .short('D')
                 .long("only-dir")
-                .help("Only directories will be displayed."), 
+                .help("Only directories will be displayed."),
         )
 }

--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -26,6 +26,7 @@ pub struct WalkData<'a> {
     pub use_apparent_size: bool,
     pub by_filecount: bool,
     pub ignore_hidden: bool,
+    pub follow_links: bool,
 }
 
 pub fn walk_it(dirs: HashSet<PathBuf>, walk_data: WalkData) -> (Vec<Node>, bool) {
@@ -144,7 +145,7 @@ fn walk(
 
                     if !ignore_file(entry, walk_data) {
                         if let Ok(data) = entry.file_type() {
-                            return if data.is_dir() && !data.is_symlink() {
+                            return if data.is_dir() || (walk_data.follow_links && data.is_symlink()) {
                                 walk(entry.path(), permissions_flag, walk_data, depth + 1)
                             } else {
                                 build_node(

--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -145,21 +145,20 @@ fn walk(
 
                     if !ignore_file(entry, walk_data) {
                         if let Ok(data) = entry.file_type() {
-                            return if data.is_dir() || (walk_data.follow_links && data.is_symlink()) {
-                                walk(entry.path(), permissions_flag, walk_data, depth + 1)
-                            } else {
-                                build_node(
-                                    entry.path(),
-                                    vec![],
-                                    walk_data.filter_regex,
-                                    walk_data.invert_filter_regex,
-                                    walk_data.use_apparent_size,
-                                    data.is_symlink(),
-                                    data.is_file(),
-                                    walk_data.by_filecount,
-                                    depth,
-                                )
-                            };
+                            if data.is_dir() || (walk_data.follow_links && data.is_symlink()) {
+                                return walk(entry.path(), permissions_flag, walk_data, depth + 1);
+                            }
+                            return build_node(
+                                entry.path(),
+                                vec![],
+                                walk_data.filter_regex,
+                                walk_data.invert_filter_regex,
+                                walk_data.use_apparent_size,
+                                data.is_symlink(),
+                                data.is_file(),
+                                walk_data.by_filecount,
+                                depth,
+                            );
                         }
                     }
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,7 @@ fn main() {
 
     let by_filecount = options.is_present("by_filecount");
     let limit_filesystem = options.is_present("limit_filesystem");
+    let follow_links = options.is_present("dereference_links");
 
     let simplified_dirs = simplify_dir_names(target_dirs);
     let allowed_filesystems = limit_filesystem
@@ -170,6 +171,7 @@ fn main() {
         use_apparent_size: config.get_apparent_size(&options),
         by_filecount,
         ignore_hidden: config.get_ignore_hidden(&options),
+        follow_links,
     };
     let _rayon = init_rayon();
 


### PR DESCRIPTION
-L is de-reference links similar to du -L

I don't see the need to support -l (ignore symlinks)