### PR TITLE
fix: check if parallelism is supported before using rayon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,7 @@ fn main() {
 
     let _rayon = init_rayon();
 
-    let (top_level_nodes, has_errors) = walk_it(simplified_dirs, walk_data);
+    let (top_level_nodes, has_errors) = walk_it(simplified_dirs, walk_data, _rayon.is_ok());
 
     let tree = match summarize_file_types {
         true => get_all_file_types(&top_level_nodes, number_of_lines),


### PR DESCRIPTION
Closes #296.

I'm pretty new to Rust. If there's a better way to do this - especially if there's a one-liner to only apply `.par_bridge()` if `parallelism` is true - please let me know and I'll change it!