### PR TITLE
feat: default option for depth from config file

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -3,11 +3,29 @@
 #   ~/.config/dust/config.toml
 #   ~/.dust.toml
 
+# Print tree upside down (biggest highest)
 reverse=true
+
+# Subdirectories will not have their path shortened
 display-full-paths=true
+
+# Use file length instead of blocks
 display-apparent-size=true
+
+# No colors will be printed
 no-colors=true
+
+# No percent bars or percentages will be displayed
 no-bars=true
+
+# No total row will be displayed
 skip-total=true
+
+# Do not display hidden files
 ignore-hidden=true
+
+# print sizes in powers of 1000 (e.g., 1.1G)
 iso=true
+
+# Depth to show
+depth=1

--- a/config/config.toml
+++ b/config/config.toml
@@ -26,6 +26,3 @@ ignore-hidden=true
 
 # print sizes in powers of 1000 (e.g., 1.1G)
 iso=true
-
-# Depth to show
-depth=1

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,7 +63,7 @@ impl Config {
     pub fn get_depth(&self, options: &ArgMatches) -> usize {
         if let Some(v) = options.value_of("depth") {
             if let Ok(v) = v.parse::<usize>() {
-                return v
+                return v;
             }
         }
 
@@ -151,7 +151,7 @@ pub fn get_config() -> Config {
 mod tests {
     #[allow(unused_imports)]
     use super::*;
-    use clap::{Command, Arg, ArgMatches};
+    use clap::{Arg, ArgMatches, Command};
 
     #[test]
     fn test_conversion() {
@@ -190,7 +190,7 @@ mod tests {
         assert_eq!(c.get_depth(&args), 5);
 
         // Config is defined and flag is not defined.
-        let c = Config{
+        let c = Config {
             depth: Some(3),
             ..Default::default()
         };
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(c.get_depth(&args), 3);
 
         // Both config and flag are defined.
-        let c = Config{
+        let c = Config {
             depth: Some(3),
             ..Default::default()
         };

--- a/src/display.rs
+++ b/src/display.rs
@@ -428,7 +428,7 @@ mod tests {
             iso: false,
         };
         DisplayData {
-            initial: initial,
+            initial,
             num_chars_needed_on_left_most: 5,
             base_size: 2_u64.pow(12), // 4.0K
             longest_string_length,

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ fn main() {
         .value_of_t("width")
         .unwrap_or_else(|_| get_width_of_terminal());
 
-    let depth = options.value_of_t("depth").unwrap_or(usize::MAX);
+    let depth = config.get_depth(&options);
 
     // If depth is set, then we set the default number_of_lines to be max
     // instead of screen height

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -147,7 +147,7 @@ pub fn test_output_screen_reader() {
     assert!(output.contains("a_file     2"));
 
     // Verify no 'symbols' reported by screen reader
-    assert!(!output.contains("│"));
+    assert!(!output.contains('│'));
 
     for block in ['█', '▓', '▒', '░'] {
         assert!(!output.contains(block));


### PR DESCRIPTION
- If `--depth` flag is not defined (or it has an invalid value), a value from the config file will be used.
- If no `depth` entry in the config file (or there is no config file), the default `usize::MAX` will be used.

Added test cases:
- no config and no flag defined              -> `usize::MAX` should be used
- config defined, but flag is not defined    -> config value should be used
- config is not defined, but flag is defined -> flag value should be used
- both config and flag is defined            -> flag value should be used

Additional changes:

- Fixed some clippy issues.
- Added comments to the example `config.toml` file. (copy from flag description)

Closes #314