### PR TITLE
Add cargo-binstall metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,10 @@ clap_mangen = "0.1"
 name = "integration"
 path = "tests/tests.rs"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/dust-v{ version }-{ target }{ archive-suffix }"
+bin-dir = "dust-v{ version }-{ target }/{ bin }{ binary-ext }"
+
 [package.metadata.deb]
 section = "utils"
 assets = [


### PR DESCRIPTION
Hello! This PR enables [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) to find release builds for the project on github. It uses a [heuristic for finding release packages](https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md), which assumes the crate name and release package name are the same. This adds metadata to Cargo.toml to provide the correct name for the github releases and binary name.

I have tested this locally with

```bash
cargo binstall --manifest-path Cargo.toml --disable-strategies quick-install du-dust
```

which results in it correctly finding https://github.com/bootandy/dust/releases/download/v0.8.5/dust-v0.8.5-x86_64-unknown-linux-gnu.tar.gz 