### PR TITLE
Fix filename completions for zsh and bash

### DIFF
--- a/completions/_dust
+++ b/completions/_dust
@@ -64,7 +64,7 @@ _dust() {
 '(-F --only-file -t --file_types)--only-dir[Only directories will be displayed.]' \
 '(-D --only-dir)-F[Only files will be displayed. (Finds your largest files)]' \
 '(-D --only-dir)--only-file[Only files will be displayed. (Finds your largest files)]' \
-'*::inputs:' \
+'*:inputs:_files' \
 && ret=0
 }
 

--- a/completions/dust.bash
+++ b/completions/dust.bash
@@ -20,8 +20,11 @@ _dust() {
     case "${cmd}" in
         dust)
             opts="-h -V -d -n -p -X -L -x -s -r -c -b -z -R -f -i -v -e -t -w -H -P -D -F --help --version --depth --number-of-lines --full-paths --ignore-directory --dereference-links --limit-filesystem --apparent-size --reverse --no-colors --no-percent-bars --min-size --screen-reader --skip-total --filecount --ignore_hidden --invert-filter --filter --file_types --terminal_width --si --no-progress --only-dir --only-file <inputs>..."
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+            if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            elif [[ ${cur} == * ]] ; then
+                _filedir
                 return 0
             fi
             case "${prev}" in


### PR DESCRIPTION
Fixes issue: Completions for zsh and bash do not work for the base filename pattern `*`.