### PR TITLE
feat(win): use size on disk for apparent size for OneDrive files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
  "clap_mangen",
  "config-file",
  "directories",
+ "filesize",
  "lscolors",
  "rayon",
  "regex",
@@ -283,6 +284,15 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "filesize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ sysinfo = "0.27"
 
 [target.'cfg(windows)'.dependencies]
 winapi-util = "0.1"
+filesize = "0.2.0"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -90,7 +90,10 @@ pub fn get_metadata(d: &Path, use_apparent_size: bool) -> Option<(u64, Option<(u
         Ok(Handle::from_file(file))
     }
 
-    fn get_metadata_expensive(d: &Path, use_apparent_size: bool) -> Option<(u64, Option<(u64, u64)>)> {
+    fn get_metadata_expensive(
+        d: &Path,
+        use_apparent_size: bool,
+    ) -> Option<(u64, Option<(u64, u64)>)> {
         use winapi_util::file::information;
 
         let h = handle_from_path_limited(d).ok()?;
@@ -126,7 +129,12 @@ pub fn get_metadata(d: &Path, use_apparent_size: bool) -> Option<(u64, Option<(u
             const FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS: u32 = 0x00400000;
             const FILE_ATTRIBUTE_OFFLINE: u32 = 0x00001000;
             // normally FILE_ATTRIBUTE_SPARSE_FILE would be enough, however Windows sometimes likes to mask it out. see: https://stackoverflow.com/q/54560454
-            const IS_PROBABLY_ONEDRIVE: u32 = FILE_ATTRIBUTE_SPARSE_FILE | FILE_ATTRIBUTE_PINNED | FILE_ATTRIBUTE_UNPINNED | FILE_ATTRIBUTE_RECALL_ON_OPEN | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS | FILE_ATTRIBUTE_OFFLINE;
+            const IS_PROBABLY_ONEDRIVE: u32 = FILE_ATTRIBUTE_SPARSE_FILE
+                | FILE_ATTRIBUTE_PINNED
+                | FILE_ATTRIBUTE_UNPINNED
+                | FILE_ATTRIBUTE_RECALL_ON_OPEN
+                | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS
+                | FILE_ATTRIBUTE_OFFLINE;
             let attr_filtered = md.file_attributes()
                 & !(FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_SYSTEM);
             if ((attr_filtered & FILE_ATTRIBUTE_ARCHIVE) != 0

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -90,16 +90,24 @@ pub fn get_metadata(d: &Path, _use_apparent_size: bool) -> Option<(u64, Option<(
         Ok(Handle::from_file(file))
     }
 
-    fn get_metadata_expensive(d: &Path) -> Option<(u64, Option<(u64, u64)>)> {
+    fn get_metadata_expensive(d: &Path, _use_apparent_size: bool) -> Option<(u64, Option<(u64, u64)>)> {
         use winapi_util::file::information;
+        use filesize::PathExt;
 
         let h = handle_from_path_limited(d).ok()?;
         let info = information(&h).ok()?;
 
-        Some((
-            info.file_size(),
-            Some((info.file_index(), info.volume_serial_number())),
-        ))
+        if _use_apparent_size {
+            Some((
+                d.size_on_disk().ok()?,
+                Some((info.file_index(), info.volume_serial_number())),
+            ))
+        } else {
+            Some((
+                info.file_size(),
+                Some((info.file_index(), info.volume_serial_number())),
+            ))
+        }
     }
 
     use std::os::windows::fs::MetadataExt;
@@ -111,18 +119,26 @@ pub fn get_metadata(d: &Path, _use_apparent_size: bool) -> Option<(u64, Option<(
             const FILE_ATTRIBUTE_SYSTEM: u32 = 0x04;
             const FILE_ATTRIBUTE_NORMAL: u32 = 0x80;
             const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10;
-
+            const FILE_ATTRIBUTE_SPARSE_FILE: u32 = 0x00000200;
+            const FILE_ATTRIBUTE_PINNED: u32 = 0x00080000;
+            const FILE_ATTRIBUTE_UNPINNED: u32 = 0x00100000;
+            const FILE_ATTRIBUTE_RECALL_ON_OPEN: u32 = 0x00040000;
+            const FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS: u32 = 0x00400000;
+            const FILE_ATTRIBUTE_OFFLINE: u32 = 0x00001000;
+            // normally FILE_ATTRIBUTE_SPARSE_FILE would be enough, however Windows sometimes likes to mask it out. see: https://stackoverflow.com/q/54560454
+            const IS_PROBABLY_ONEDRIVE: u32 = FILE_ATTRIBUTE_SPARSE_FILE | FILE_ATTRIBUTE_PINNED | FILE_ATTRIBUTE_UNPINNED | FILE_ATTRIBUTE_RECALL_ON_OPEN | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS | FILE_ATTRIBUTE_OFFLINE;
             let attr_filtered = md.file_attributes()
                 & !(FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_SYSTEM);
-            if (attr_filtered & FILE_ATTRIBUTE_ARCHIVE) != 0
+            if ((attr_filtered & FILE_ATTRIBUTE_ARCHIVE) != 0
                 || (attr_filtered & FILE_ATTRIBUTE_DIRECTORY) != 0
-                || md.file_attributes() == FILE_ATTRIBUTE_NORMAL
+                || md.file_attributes() == FILE_ATTRIBUTE_NORMAL)
+                && !((attr_filtered & IS_PROBABLY_ONEDRIVE != 0) && _use_apparent_size)
             {
                 Some((md.len(), None))
             } else {
-                get_metadata_expensive(d)
+                get_metadata_expensive(d, _use_apparent_size)
             }
         }
-        _ => get_metadata_expensive(d),
+        _ => get_metadata_expensive(d, _use_apparent_size),
     }
 }


### PR DESCRIPTION
Resolves #366 

Before: 
![image](https://github.com/bootandy/dust/assets/101084582/32d77da7-2fdf-4518-8faa-9c6d9365e664)
![image](https://github.com/bootandy/dust/assets/101084582/fd73519b-b7ff-4104-a6af-816e30e488a7)
After: 
<img width="644" alt="image" src="https://github.com/bootandy/dust/assets/101084582/23df40fa-9a5d-4eab-ac0e-db5cd6e9cac2">
<img width="176" alt="image" src="https://github.com/bootandy/dust/assets/101084582/c49b4b1c-020a-418e-a007-e72a7ae4814b">
