### PR TITLE
Add Anaconda install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Because I want an easy way to see where my disk is being used.
 
 - `pacstall -I dust-bin`
 
+### Anaconda (conda-forge)
+
+- `conda install -c conda-forge dust`
+
 #### [deb-get](https://github.com/wimpysworld/deb-get) (Debian/Ubuntu)
 
 - `deb-get install du-dust`


### PR DESCRIPTION
### Changes

- Adds the method for installing `dust` from `conda-forge` ([feedstock here](https://github.com/conda-forge/dust-feedstock))

### Comments

If you'd like to be listed as a package maintainer, please let me know, and I'll add you. Effort is minimal; maintenance is mostly automated.