### PR TITLE
fix: bug: Si detection was backwards.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -185,7 +185,8 @@ mod tests {
         assert_eq!(convert_min_size("95RUBBISH"), None);
         assert_eq!(convert_min_size("10Ki"), Some(10 * 1024));
         assert_eq!(convert_min_size("10MiB"), Some(10 * 1024usize.pow(2)));
-        assert_eq!(convert_min_size("10M"), Some(10 * 1000usize.pow(2)));
+        assert_eq!(convert_min_size("10M"), Some(10 * 1024usize.pow(2)));
+        assert_eq!(convert_min_size("10Mb"), Some(10 * 1000usize.pow(2)));
         assert_eq!(convert_min_size("2Gi"), Some(2 * 1024usize.pow(3)));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,23 +183,23 @@ mod tests {
         assert_eq!(convert_min_size("55"), Some(55));
         assert_eq!(convert_min_size("12344321"), Some(12344321));
         assert_eq!(convert_min_size("95RUBBISH"), None);
-        assert_eq!(convert_min_size("10K"), Some(10 * 1024));
-        assert_eq!(convert_min_size("10M"), Some(10 * 1024usize.pow(2)));
-        assert_eq!(convert_min_size("10MiB"), Some(10 * 1000usize.pow(2)));
-        assert_eq!(convert_min_size("2G"), Some(2 * 1024usize.pow(3)));
+        assert_eq!(convert_min_size("10Ki"), Some(10 * 1024));
+        assert_eq!(convert_min_size("10MiB"), Some(10 * 1024usize.pow(2)));
+        assert_eq!(convert_min_size("10M"), Some(10 * 1000usize.pow(2)));
+        assert_eq!(convert_min_size("2Gi"), Some(2 * 1024usize.pow(3)));
     }
 
     #[test]
     fn test_min_size_from_config_applied_or_overridden() {
         let c = Config {
-            min_size: Some("1K".to_owned()),
+            min_size: Some("1KiB".to_owned()),
             ..Default::default()
         };
         assert_eq!(c._get_min_size(None), Some(1024));
-        assert_eq!(c._get_min_size(Some(&"2K".into())), Some(2048));
+        assert_eq!(c._get_min_size(Some(&"2KiB".into())), Some(2048));
 
-        assert_eq!(c._get_min_size(Some(&"1kib".into())), Some(1000));
-        assert_eq!(c._get_min_size(Some(&"2KiB".into())), Some(2000));
+        assert_eq!(c._get_min_size(Some(&"1kb".into())), Some(1000));
+        assert_eq!(c._get_min_size(Some(&"2KB".into())), Some(2000));
     }
 
     #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -411,11 +411,14 @@ fn get_pretty_name(
 
 // If we are working with SI units or not
 pub fn get_type_of_thousand(output_str: &str) -> u64 {
-    let is_si = output_str.contains('i'); // si, KiB, MiB, etc
-    if is_si {
-        1000
-    } else {
+    if output_str.is_empty() {
         1024
+    } else if output_str == "si" {
+        1000
+    } else if output_str.contains('i') {
+        1024
+    } else {
+        1000
     }
 }
 
@@ -557,14 +560,14 @@ mod tests {
         let hrn = human_readable_number;
         assert_eq!(hrn(1023, "b"), "1023B");
         assert_eq!(hrn(1000 * 1000, "bytes"), "1000000B");
-        assert_eq!(hrn(1023, "kb"), "0K");
-        assert_eq!(hrn(1023, "kib"), "1K");
-        assert_eq!(hrn(1024, "kb"), "1K");
-        assert_eq!(hrn(1024 * 512, "kb"), "512K");
-        assert_eq!(hrn(1024 * 1024, "kb"), "1024K");
-        assert_eq!(hrn(1024 * 1000 * 1000 * 20, "kb"), "20000000K");
-        assert_eq!(hrn(1024 * 1024 * 1000 * 20, "mb"), "20000M");
-        assert_eq!(hrn(1024 * 1024 * 1024 * 20, "gb"), "20G");
+        assert_eq!(hrn(1023, "kb"), "1K");
+        assert_eq!(hrn(1023, "kib"), "0K");
+        assert_eq!(hrn(1024, "kib"), "1K");
+        assert_eq!(hrn(1024 * 512, "kib"), "512K");
+        assert_eq!(hrn(1024 * 1024, "kib"), "1024K");
+        assert_eq!(hrn(1024 * 1000 * 1000 * 20, "kib"), "20000000K");
+        assert_eq!(hrn(1024 * 1024 * 1000 * 20, "mib"), "20000M");
+        assert_eq!(hrn(1024 * 1024 * 1024 * 20, "gib"), "20G");
     }
 
     #[cfg(test)]

--- a/src/display.rs
+++ b/src/display.rs
@@ -415,7 +415,7 @@ pub fn get_type_of_thousand(output_str: &str) -> u64 {
         1024
     } else if output_str == "si" {
         1000
-    } else if output_str.contains('i') {
+    } else if output_str.contains('i') || output_str.len() == 1 {
         1024
     } else {
         1000
@@ -555,12 +555,14 @@ mod tests {
         assert_eq!(human_readable_number(1024 * 100, "si"), "102K");
     }
 
+    // Refer to https://en.wikipedia.org/wiki/Byte#Multiple-byte_units
     #[test]
     fn test_human_readable_number_kb() {
         let hrn = human_readable_number;
         assert_eq!(hrn(1023, "b"), "1023B");
         assert_eq!(hrn(1000 * 1000, "bytes"), "1000000B");
         assert_eq!(hrn(1023, "kb"), "1K");
+        assert_eq!(hrn(1023, "k"), "0K");
         assert_eq!(hrn(1023, "kib"), "0K");
         assert_eq!(hrn(1024, "kib"), "1K");
         assert_eq!(hrn(1024 * 512, "kib"), "512K");


### PR DESCRIPTION
```
kB - means kilobyte 10**3
KiB - means kibibyte 1024 / 2**10
```