### PR TITLE
Allow options to be set in any position

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,6 @@ pub fn build_cli() -> Command {
     Command::new("Dust")
         .about("Like du but more intuitive")
         .version(env!("CARGO_PKG_VERSION"))
-        .trailing_var_arg(true)
         .arg(
             Arg::new("depth")
                 .short('d')


### PR DESCRIPTION
Currently options following regular arguments are not interpreted as options. This fixes that.

Users can still treat values starting with a hyphen (`-`) as regular arguments by using `--`, e.g.:

    dust -d 2 -r ~/Documents -F -- --this-is-my-dir