### PR TITLE
refactor: cleanup -j / --output-json flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Usage: dust -R (For screen readers. Removes bars/symbols. Adds new column: depth
 Usage: dust -S (Custom Stack size - Use if you see: 'fatal runtime error: stack overflow' (default allocation: low memory=1048576, high memory=1073741824)"),
 Usage: dust --skip-total (No total row will be displayed)
 Usage: dust -z 40000/30MB/20kib (Exclude output files/directories below size 40000 bytes / 30MB / 20KiB)
+Usage: dust -j (Prints JSON representation of directories, try: dust -j  | jq)
 ```
 
 ## Config file

--- a/src/display_node.rs
+++ b/src/display_node.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+use serde::Serialize;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize)]
 pub struct DisplayNode {
     // Note: the order of fields in important here, for PartialEq and PartialOrd
     pub size: u64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,11 +39,6 @@ use terminal_size::{terminal_size, Height, Width};
 use utils::get_filesystem_devices;
 use utils::simplify_dir_names;
 
-use crate::node::Node;
-use chrono::Local;
-use std::fs::File;
-use std::io::Write;
-
 static DEFAULT_NUMBER_OF_LINES: usize = 30;
 static DEFAULT_TERMINAL_WIDTH: usize = 80;
 
@@ -234,18 +229,6 @@ fn main() {
 
     let top_level_nodes = walk_it(simplified_dirs, &walk_data);
 
-    if config.get_output_json(&options) {
-        let datetime = Local::now().format("%Y%m%d%H%M%S").to_string();
-        let output_filename = format!("node-{}.json", datetime);
-        let result = output_json(&output_filename, &top_level_nodes);
-        match result {
-            Ok(..) => {}
-            Err(err) => {
-                eprintln!("Error: {}", err)
-            }
-        }
-    }
-
     let tree = match summarize_file_types {
         true => get_all_file_types(&top_level_nodes, number_of_lines),
         false => {
@@ -302,13 +285,18 @@ fn main() {
             output_format,
             bars_on_right: config.get_bars_on_right(&options),
         };
-        draw_it(
-            idd,
-            config.get_no_bars(&options),
-            terminal_width,
-            &root_node,
-            config.get_skip_total(&options),
-        )
+
+        if config.get_output_json(&options) {
+            println!("{}", serde_json::to_string(&root_node).unwrap());
+        } else {
+            draw_it(
+                idd,
+                config.get_no_bars(&options),
+                terminal_width,
+                &root_node,
+                config.get_skip_total(&options),
+            )
+        }
     }
 }
 
@@ -321,13 +309,6 @@ fn init_rayon(stack_size: &Option<usize>, threads: &Option<usize>) {
             eprintln!("Problem initializing rayon, try: export RAYON_NUM_THREADS=1")
         }
     }
-}
-
-fn output_json(output_filename: &str, top_level_nodes: &Vec<Node>) -> std::io::Result<()> {
-    let serialized: String = serde_json::to_string(&top_level_nodes).unwrap();
-    let mut file = File::create(output_filename)?;
-    file.write_all(serialized.as_bytes())?;
-    Ok(())
 }
 
 fn build_thread_pool(

--- a/src/node.rs
+++ b/src/node.rs
@@ -3,11 +3,10 @@ use crate::utils::is_filtered_out_due_to_invert_regex;
 use crate::utils::is_filtered_out_due_to_regex;
 
 use regex::Regex;
-use serde::Serialize;
 use std::cmp::Ordering;
 use std::path::PathBuf;
 
-#[derive(Debug, Eq, Clone, Serialize)]
+#[derive(Debug, Eq, Clone)]
 pub struct Node {
     pub name: PathBuf,
     pub size: u64,


### PR DESCRIPTION
Stop -j writing to a file, print to stdout instead.