### PR TITLE
eprint problematic folders

### DIFF
--- a/completions/_dust
+++ b/completions/_dust
@@ -66,6 +66,7 @@ _dust() {
 '(-d --depth -D --only-dir)--file_types[show only these file types]' \
 '-P[Disable the progress indication.]' \
 '--no-progress[Disable the progress indication.]' \
+'--print-errors[Print path with errors.]' \
 '(-F --only-file -t --file_types)-D[Only directories will be displayed.]' \
 '(-F --only-file -t --file_types)--only-dir[Only directories will be displayed.]' \
 '(-D --only-dir)-F[Only files will be displayed. (Finds your largest files)]' \

--- a/completions/_dust.ps1
+++ b/completions/_dust.ps1
@@ -72,6 +72,7 @@ Register-ArgumentCompleter -Native -CommandName 'dust' -ScriptBlock {
             [CompletionResult]::new('--file_types', 'file_types', [CompletionResultType]::ParameterName, 'show only these file types')
             [CompletionResult]::new('-P', 'P ', [CompletionResultType]::ParameterName, 'Disable the progress indication.')
             [CompletionResult]::new('--no-progress', 'no-progress', [CompletionResultType]::ParameterName, 'Disable the progress indication.')
+            [CompletionResult]::new('--print-errors', 'print-errors', [CompletionResultType]::ParameterName, 'Print path with errors.')
             [CompletionResult]::new('-D', 'D ', [CompletionResultType]::ParameterName, 'Only directories will be displayed.')
             [CompletionResult]::new('--only-dir', 'only-dir', [CompletionResultType]::ParameterName, 'Only directories will be displayed.')
             [CompletionResult]::new('-F', 'F ', [CompletionResultType]::ParameterName, 'Only files will be displayed. (Finds your largest files)')

--- a/completions/dust.bash
+++ b/completions/dust.bash
@@ -19,7 +19,7 @@ _dust() {
 
     case "${cmd}" in
         dust)
-            opts="-d -T -n -p -X -I -L -x -s -r -c -C -b -B -z -R -f -i -v -e -t -w -P -D -F -o -S -j -h -V --depth --threads --number-of-lines --full-paths --ignore-directory --ignore-all-in-file --dereference-links --limit-filesystem --apparent-size --reverse --no-colors --force-colors --no-percent-bars --bars-on-right --min-size --screen-reader --skip-total --filecount --ignore_hidden --invert-filter --filter --file_types --terminal_width --no-progress --only-dir --only-file --output-format --stack-size --output-json --help --version [PATH]..."
+            opts="-d -T -n -p -X -I -L -x -s -r -c -C -b -B -z -R -f -i -v -e -t -w -P -D -F -o -S -j -h -V --depth --threads --number-of-lines --full-paths --ignore-directory --ignore-all-in-file --dereference-links --limit-filesystem --apparent-size --reverse --no-colors --force-colors --no-percent-bars --bars-on-right --min-size --screen-reader --skip-total --filecount --ignore_hidden --invert-filter --filter --file_types --terminal_width --no-progress --print-errors --only-dir --only-file --output-format --stack-size --output-json --help --version [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/dust.elv
+++ b/completions/dust.elv
@@ -69,6 +69,7 @@ set edit:completion:arg-completer[dust] = {|@words|
             cand --file_types 'show only these file types'
             cand -P 'Disable the progress indication.'
             cand --no-progress 'Disable the progress indication.'
+            cand --print-errors 'Print path with errors.'
             cand -D 'Only directories will be displayed.'
             cand --only-dir 'Only directories will be displayed.'
             cand -F 'Only files will be displayed. (Finds your largest files)'

--- a/completions/dust.fish
+++ b/completions/dust.fish
@@ -24,6 +24,7 @@ complete -c dust -s f -l filecount -d 'Directory \'size\' is number of child fil
 complete -c dust -s i -l ignore_hidden -d 'Do not display hidden files'
 complete -c dust -s t -l file_types -d 'show only these file types'
 complete -c dust -s P -l no-progress -d 'Disable the progress indication.'
+complete -c dust -l print-errors -d 'Print path with errors.'
 complete -c dust -s D -l only-dir -d 'Only directories will be displayed.'
 complete -c dust -s F -l only-file -d 'Only files will be displayed. (Finds your largest files)'
 complete -c dust -s j -l output-json -d 'Output the directory tree as json to the current directory'

--- a/man-page/dust.1
+++ b/man-page/dust.1
@@ -4,7 +4,7 @@
 .SH NAME
 Dust \- Like du but more intuitive
 .SH SYNOPSIS
-\fBdust\fR [\fB\-d\fR|\fB\-\-depth\fR] [\fB\-T\fR|\fB\-\-threads\fR] [\fB\-n\fR|\fB\-\-number\-of\-lines\fR] [\fB\-p\fR|\fB\-\-full\-paths\fR] [\fB\-X\fR|\fB\-\-ignore\-directory\fR] [\fB\-I\fR|\fB\-\-ignore\-all\-in\-file\fR] [\fB\-L\fR|\fB\-\-dereference\-links\fR] [\fB\-x\fR|\fB\-\-limit\-filesystem\fR] [\fB\-s\fR|\fB\-\-apparent\-size\fR] [\fB\-r\fR|\fB\-\-reverse\fR] [\fB\-c\fR|\fB\-\-no\-colors\fR] [\fB\-C\fR|\fB\-\-force\-colors\fR] [\fB\-b\fR|\fB\-\-no\-percent\-bars\fR] [\fB\-B\fR|\fB\-\-bars\-on\-right\fR] [\fB\-z\fR|\fB\-\-min\-size\fR] [\fB\-R\fR|\fB\-\-screen\-reader\fR] [\fB\-\-skip\-total\fR] [\fB\-f\fR|\fB\-\-filecount\fR] [\fB\-i\fR|\fB\-\-ignore_hidden\fR] [\fB\-v\fR|\fB\-\-invert\-filter\fR] [\fB\-e\fR|\fB\-\-filter\fR] [\fB\-t\fR|\fB\-\-file_types\fR] [\fB\-w\fR|\fB\-\-terminal_width\fR] [\fB\-P\fR|\fB\-\-no\-progress\fR] [\fB\-D\fR|\fB\-\-only\-dir\fR] [\fB\-F\fR|\fB\-\-only\-file\fR] [\fB\-o\fR|\fB\-\-output\-format\fR] [\fB\-S\fR|\fB\-\-stack\-size\fR] [\fB\-j\fR|\fB\-\-output\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIPATH\fR] 
+\fBdust\fR [\fB\-d\fR|\fB\-\-depth\fR] [\fB\-T\fR|\fB\-\-threads\fR] [\fB\-n\fR|\fB\-\-number\-of\-lines\fR] [\fB\-p\fR|\fB\-\-full\-paths\fR] [\fB\-X\fR|\fB\-\-ignore\-directory\fR] [\fB\-I\fR|\fB\-\-ignore\-all\-in\-file\fR] [\fB\-L\fR|\fB\-\-dereference\-links\fR] [\fB\-x\fR|\fB\-\-limit\-filesystem\fR] [\fB\-s\fR|\fB\-\-apparent\-size\fR] [\fB\-r\fR|\fB\-\-reverse\fR] [\fB\-c\fR|\fB\-\-no\-colors\fR] [\fB\-C\fR|\fB\-\-force\-colors\fR] [\fB\-b\fR|\fB\-\-no\-percent\-bars\fR] [\fB\-B\fR|\fB\-\-bars\-on\-right\fR] [\fB\-z\fR|\fB\-\-min\-size\fR] [\fB\-R\fR|\fB\-\-screen\-reader\fR] [\fB\-\-skip\-total\fR] [\fB\-f\fR|\fB\-\-filecount\fR] [\fB\-i\fR|\fB\-\-ignore_hidden\fR] [\fB\-v\fR|\fB\-\-invert\-filter\fR] [\fB\-e\fR|\fB\-\-filter\fR] [\fB\-t\fR|\fB\-\-file_types\fR] [\fB\-w\fR|\fB\-\-terminal_width\fR] [\fB\-P\fR|\fB\-\-no\-progress\fR] [\fB\-\-print\-errors\fR] [\fB\-D\fR|\fB\-\-only\-dir\fR] [\fB\-F\fR|\fB\-\-only\-file\fR] [\fB\-o\fR|\fB\-\-output\-format\fR] [\fB\-S\fR|\fB\-\-stack\-size\fR] [\fB\-j\fR|\fB\-\-output\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIPATH\fR] 
 .SH DESCRIPTION
 Like du but more intuitive
 .SH OPTIONS
@@ -80,6 +80,9 @@ Specify width of output overriding the auto detection of terminal width
 .TP
 \fB\-P\fR, \fB\-\-no\-progress\fR
 Disable the progress indication.
+.TP
+\fB\-\-print\-errors\fR
+Print path with errors.
 .TP
 \fB\-D\fR, \fB\-\-only\-dir\fR
 Only directories will be displayed.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,6 +194,12 @@ pub fn build_cli() -> Command {
                 .help("Disable the progress indication."),
         )
         .arg(
+            Arg::new("print_errors")
+                .long("print-errors")
+                .action(clap::ArgAction::SetTrue)
+                .help("Print path with errors."),
+        )
+        .arg(
             Arg::new("only_dir")
                 .short('D')
                 .long("only-dir")

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub stack_size: Option<usize>,
     pub threads: Option<usize>,
     pub output_json: Option<bool>,
+    pub print_errors: Option<bool>,
 }
 
 impl Config {
@@ -104,6 +105,10 @@ impl Config {
     }
     pub fn get_only_dir(&self, options: &ArgMatches) -> bool {
         Some(true) == self.only_dir || options.get_flag("only_dir")
+    }
+
+    pub fn get_print_errors(&self, options: &ArgMatches) -> bool {
+        Some(true) == self.print_errors || options.get_flag("print_errors")
     }
     pub fn get_only_file(&self, options: &ArgMatches) -> bool {
         Some(true) == self.only_file || options.get_flag("only_file")

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,7 +269,6 @@ fn main() {
     }
 
     let final_errors = walk_data.errors.lock().unwrap();
-    let failed_permissions = final_errors.no_permissions;
     if !final_errors.file_not_found.is_empty() {
         let err = final_errors
             .file_not_found
@@ -279,8 +278,14 @@ fn main() {
             .join(", ");
         eprintln!("No such file or directory: {}", err);
     }
-    if failed_permissions {
-        eprintln!("Did not have permissions for all directories");
+    if !final_errors.no_permissions.is_empty() {
+        let err = final_errors
+            .no_permissions
+            .iter()
+            .map(|a| a.as_ref())
+            .collect::<Vec<&str>>()
+            .join(", ");
+        eprintln!("Did not have permissions for directories: {}", err);
     }
     if !final_errors.unknown_error.is_empty() {
         let err = final_errors

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,13 +279,19 @@ fn main() {
         eprintln!("No such file or directory: {}", err);
     }
     if !final_errors.no_permissions.is_empty() {
-        let err = final_errors
-            .no_permissions
-            .iter()
-            .map(|a| a.as_ref())
-            .collect::<Vec<&str>>()
-            .join(", ");
-        eprintln!("Did not have permissions for directories: {}", err);
+        if config.get_print_errors(&options) {
+            let err = final_errors
+                .no_permissions
+                .iter()
+                .map(|a| a.as_ref())
+                .collect::<Vec<&str>>()
+                .join(", ");
+            eprintln!("Did not have permissions for directories: {}", err);
+        } else {
+            eprintln!(
+                "Did not have permissions for all directories (add --print-errors to see errors)"
+            );
+        }
     }
     if !final_errors.unknown_error.is_empty() {
         let err = final_errors

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -70,7 +70,7 @@ impl PAtomicInfo {
 
 #[derive(Default)]
 pub struct RuntimeErrors {
-    pub no_permissions: bool,
+    pub no_permissions: HashSet<String>,
     pub file_not_found: HashSet<String>,
     pub unknown_error: HashSet<String>,
     pub abort: bool,

--- a/tests/test_exact_output.rs
+++ b/tests/test_exact_output.rs
@@ -244,14 +244,34 @@ fn apparent_size_output() -> Vec<String> {
 
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
-pub fn test_permission() {
+pub fn test_permission_normal() {
     Command::new("sh")
         .arg("-c")
         .arg("mkdir -p /tmp/unreadable_folder && chmod 000 /tmp/unreadable_folder")
         .output()
         .unwrap();
     let command_args = vec!["/tmp/unreadable_folder"];
-    let permission_msg = r#"Did not have permissions"#.trim().to_string();
+    let permission_msg = r#"Did not have permissions for all"#.trim().to_string();
+    exact_output_test(command_args, vec![], vec![permission_msg]);
+
+    Command::new("sh")
+        .arg("-c")
+        .arg("chmod 555 /tmp/unreadable_folder")
+        .output()
+        .unwrap();
+}
+
+#[cfg_attr(target_os = "windows", ignore)]
+#[test]
+pub fn test_permission_flag() {
+    Command::new("sh")
+        .arg("-c")
+        .arg("mkdir -p /tmp/unreadable_folder && chmod 000 /tmp/unreadable_folder")
+        .output()
+        .unwrap();
+    // add the flag to CLI
+    let command_args = vec!["--print-errors", "/tmp/unreadable_folder"];
+    let permission_msg = r#"Did not have permissions for directories"#.trim().to_string();
     exact_output_test(command_args, vec![], vec![permission_msg]);
 
     Command::new("sh")


### PR DESCRIPTION
This PR change the `Did not have permissions..` message to print problematic folders/files


Why this PR: I think it's useful to have the list of the problematic folders/files