### PR TITLE
fix: issue 386 --only-file displays full paths even without --full-paths

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,10 +52,9 @@ impl Config {
         Some(true) == self.ignore_hidden || options.get_flag("ignore_hidden")
     }
     pub fn get_full_paths(&self, options: &ArgMatches) -> bool {
-        // If we are only showing files, always show full paths
         Some(true) == self.display_full_paths
             || options.get_flag("display_full_paths")
-            || self.get_only_file(options)
+            // || self.get_only_file(options)
     }
     pub fn get_reverse(&self, options: &ArgMatches) -> bool {
         Some(true) == self.reverse || options.get_flag("reverse")


### PR DESCRIPTION
#Background
--only-file displays full paths even without --full-paths #386
 If only-file is provided without the --full-pathss parameter, the output file path does not contain the full path

# Full Changelogs
- fix: --only-file displays full paths even without --full-paths

# Issue Reference
Fix https://github.com/bootandy/dust/issues/386 --only-file displays full paths even without --full-paths 

# Test Result
![image](https://github.com/bootandy/dust/assets/20339490/ba161a6a-618c-4992-b23d-883234930c20)
