### PR TITLE
Explicit lifecycle that can be omitted

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -573,7 +573,7 @@ mod tests {
     }
 
     #[cfg(test)]
-    fn build_draw_data<'a>(disp: &'a DisplayData, size: u32) -> (DrawData<'a>, DisplayNode) {
+    fn build_draw_data(disp: &DisplayData, size: u32) -> (DrawData<'_>, DisplayNode) {
         let n = DisplayNode {
             name: PathBuf::from("/short"),
             size: 2_u64.pow(size),


### PR DESCRIPTION
in src/display.rs file: the following explicit lifetimes could be elided: 'a