### PR TITLE
Fix -x option behavior

### DIFF
--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -111,7 +111,7 @@ fn ignore_file(entry: &DirEntry, walk_data: &WalkData) -> bool {
     let is_dot_file = entry.file_name().to_str().unwrap_or("").starts_with('.');
     let is_ignored_path = walk_data.ignore_directories.contains(&entry.path());
 
-    let size_inode_device = get_metadata(&entry.path(), false);
+    let size_inode_device = get_metadata(entry.path(), false);
     if let Some((_size, Some((_id, dev)), (modified_time, accessed_time, changed_time))) =
         size_inode_device
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,9 +193,9 @@ fn main() {
     let follow_links = options.get_flag("dereference_links");
 
     let allowed_filesystems = limit_filesystem
-        .then(|| get_filesystem_devices(target_dirs.iter().cloned()))
+        .then(|| get_filesystem_devices(&target_dirs))
         .unwrap_or_default();
-    let simplified_dirs = simplify_dir_names(target_dirs);
+    let simplified_dirs = simplify_dir_names(&target_dirs);
 
     let ignored_full_path: HashSet<PathBuf> = ignore_directories
         .into_iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,10 +192,10 @@ fn main() {
     let limit_filesystem = options.get_flag("limit_filesystem");
     let follow_links = options.get_flag("dereference_links");
 
-    let simplified_dirs = simplify_dir_names(target_dirs);
     let allowed_filesystems = limit_filesystem
-        .then(|| get_filesystem_devices(simplified_dirs.iter()))
+        .then(|| get_filesystem_devices(target_dirs.iter().cloned()))
         .unwrap_or_default();
+    let simplified_dirs = simplify_dir_names(target_dirs);
 
     let ignored_full_path: HashSet<PathBuf> = ignore_directories
         .into_iter()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,11 +34,12 @@ pub fn simplify_dir_names<P: AsRef<Path>>(filenames: Vec<P>) -> HashSet<PathBuf>
     top_level_names
 }
 
-pub fn get_filesystem_devices<'a, P: IntoIterator<Item = &'a PathBuf>>(paths: P) -> HashSet<u64> {
+pub fn get_filesystem_devices<'a, P: IntoIterator<Item = &'a str>>(paths: P) -> HashSet<u64> {
     // Gets the device ids for the filesystems which are used by the argument paths
     paths
         .into_iter()
-        .filter_map(|p| match get_metadata(p, false) {
+        .map(PathBuf::from)
+        .filter_map(|p| match get_metadata(&p, false) {
             Some((_size, Some((_id, dev)), _time)) => Some(dev),
             _ => None,
         })

--- a/tests/test_exact_output.rs
+++ b/tests/test_exact_output.rs
@@ -58,7 +58,7 @@ fn initialize() {
     });
 }
 
-fn run_cmd<T: AsRef<OsStr>>(command_args: Vec<T>) -> Output {
+fn run_cmd<T: AsRef<OsStr>>(command_args: &[T]) -> Output {
     initialize();
     let mut to_run = &mut Command::cargo_bin("dust").unwrap();
     for p in command_args {
@@ -67,7 +67,7 @@ fn run_cmd<T: AsRef<OsStr>>(command_args: Vec<T>) -> Output {
     to_run.unwrap()
 }
 
-fn exact_stdout_test<T: AsRef<OsStr>>(command_args: Vec<T>, valid_stdout: Vec<String>) {
+fn exact_stdout_test<T: AsRef<OsStr>>(command_args: &[T], valid_stdout: Vec<String>) {
     let to_run = run_cmd(command_args);
 
     let stdout_output = str::from_utf8(&to_run.stdout).unwrap().to_owned();
@@ -82,7 +82,7 @@ fn exact_stdout_test<T: AsRef<OsStr>>(command_args: Vec<T>, valid_stdout: Vec<St
     assert!(will_fail);
 }
 
-fn exact_stderr_test<T: AsRef<OsStr>>(command_args: Vec<T>, valid_stderr: String) {
+fn exact_stderr_test<T: AsRef<OsStr>>(command_args: &[T], valid_stderr: String) {
     let to_run = run_cmd(command_args);
 
     let stderr_output = str::from_utf8(&to_run.stderr).unwrap().trim();
@@ -94,20 +94,20 @@ fn exact_stderr_test<T: AsRef<OsStr>>(command_args: Vec<T>, valid_stderr: String
 #[test]
 pub fn test_main_basic() {
     // -c is no color mode - This makes testing much simpler
-    exact_stdout_test(vec!["-c", "-B", "/tmp/test_dir/"], main_output());
+    exact_stdout_test(&["-c", "-B", "/tmp/test_dir/"], main_output());
 }
 
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
 pub fn test_main_multi_arg() {
-    let command_args = vec![
+    let command_args = [
         "-c",
         "-B",
         "/tmp/test_dir/many/",
         "/tmp/test_dir",
         "/tmp/test_dir",
     ];
-    exact_stdout_test(command_args, main_output());
+    exact_stdout_test(&command_args, main_output());
 }
 
 fn main_output() -> Vec<String> {
@@ -137,8 +137,8 @@ fn main_output() -> Vec<String> {
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
 pub fn test_main_long_paths() {
-    let command_args = vec!["-c", "-p", "-B", "/tmp/test_dir/"];
-    exact_stdout_test(command_args, main_output_long_paths());
+    let command_args = ["-c", "-p", "-B", "/tmp/test_dir/"];
+    exact_stdout_test(&command_args, main_output_long_paths());
 }
 
 fn main_output_long_paths() -> Vec<String> {
@@ -165,8 +165,8 @@ fn main_output_long_paths() -> Vec<String> {
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
 pub fn test_substring_of_names_and_long_names() {
-    let command_args = vec!["-c", "-B", "/tmp/test_dir2"];
-    exact_stdout_test(command_args, no_substring_of_names_output());
+    let command_args = ["-c", "-B", "/tmp/test_dir2"];
+    exact_stdout_test(&command_args, no_substring_of_names_output());
 }
 
 fn no_substring_of_names_output() -> Vec<String> {
@@ -199,8 +199,8 @@ fn no_substring_of_names_output() -> Vec<String> {
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
 pub fn test_unicode_directories() {
-    let command_args = vec!["-c", "-B", "/tmp/test_dir_unicode"];
-    exact_stdout_test(command_args, unicode_dir());
+    let command_args = ["-c", "-B", "/tmp/test_dir_unicode"];
+    exact_stdout_test(&command_args, unicode_dir());
 }
 
 fn unicode_dir() -> Vec<String> {
@@ -226,8 +226,8 @@ fn unicode_dir() -> Vec<String> {
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
 pub fn test_apparent_size() {
-    let command_args = vec!["-c", "-s", "-b", "/tmp/test_dir"];
-    exact_stdout_test(command_args, apparent_size_output());
+    let command_args = ["-c", "-s", "-b", "/tmp/test_dir"];
+    exact_stdout_test(&command_args, apparent_size_output());
 }
 
 fn apparent_size_output() -> Vec<String> {
@@ -252,22 +252,22 @@ fn apparent_size_output() -> Vec<String> {
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
 pub fn test_permission_normal() {
-    let command_args = vec![UNREADABLE_DIR_PATH];
+    let command_args = [UNREADABLE_DIR_PATH];
     let permission_msg =
         r#"Did not have permissions for all directories (add --print-errors to see errors)"#
             .trim()
             .to_string();
-    exact_stderr_test(command_args, permission_msg);
+    exact_stderr_test(&command_args, permission_msg);
 }
 
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
 pub fn test_permission_flag() {
     // add the flag to CLI
-    let command_args = vec!["--print-errors", UNREADABLE_DIR_PATH];
+    let command_args = ["--print-errors", UNREADABLE_DIR_PATH];
     let permission_msg = format!(
         "Did not have permissions for directories: {}",
         UNREADABLE_DIR_PATH
     );
-    exact_stderr_test(command_args, permission_msg);
+    exact_stderr_test(&command_args, permission_msg);
 }


### PR DESCRIPTION
This PR addresses an issue where `target_dirs` were being optimized out before being passed to the `get_filesystem_devices()` function. The changes in this PR ensure that `target_dirs` are passed directly to `get_filesystem_devices()`, and only then are they simplified.

Example of a command that currently doesn't work correctly:
```sh
dust -x $(findmnt -S tmpfs -o target -n)
```

It should show the usage of all tmpfs mounts, but it currently shows just the the root mountpoints like `/run`, since all the mountpoints nested under it are optimized out.