### PR TITLE
deps: update winapi-util to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,11 +919,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
starting with 0.1.7, winapi-util uses windows-rs, which is maintained official bindings from MS. this reduces dependence on winapi, which is abandoned for more than 3 years