### PR TITLE
fix: retrieve metadata for symbolic links without following them

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -228,7 +228,7 @@ fn main() {
     let follow_links = options.get_flag("dereference_links");
 
     let allowed_filesystems = limit_filesystem
-        .then(|| get_filesystem_devices(&target_dirs))
+        .then(|| get_filesystem_devices(&target_dirs, follow_links))
         .unwrap_or_default();
     let simplified_dirs = simplify_dir_names(&target_dirs);
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -28,16 +28,16 @@ pub fn build_node(
     let use_apparent_size = walk_data.use_apparent_size;
     let by_filecount = walk_data.by_filecount;
 
-    get_metadata(&dir, use_apparent_size).map(|data| {
-        let inode_device = if is_symlink && !use_apparent_size {
-            None
-        } else {
-            data.1
-        };
+    get_metadata(
+        &dir,
+        use_apparent_size,
+        walk_data.follow_links && is_symlink,
+    )
+    .map(|data| {
+        let inode_device = data.1;
 
         let size = if is_filtered_out_due_to_regex(walk_data.filter_regex, &dir)
             || is_filtered_out_due_to_invert_regex(walk_data.invert_filter_regex, &dir)
-            || (is_symlink && !use_apparent_size)
             || by_filecount && !is_file
             || [
                 (&walk_data.filter_modified_time, data.2 .0),

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -17,9 +17,15 @@ type FileTime = (i64, i64, i64);
 pub fn get_metadata<P: AsRef<Path>>(
     path: P,
     use_apparent_size: bool,
+    follow_links: bool,
 ) -> Option<(u64, Option<InodeAndDevice>, FileTime)> {
     use std::os::unix::fs::MetadataExt;
-    match path.as_ref().metadata() {
+    let metadata = if follow_links {
+        path.as_ref().metadata()
+    } else {
+        path.as_ref().symlink_metadata()
+    };
+    match metadata {
         Ok(md) => {
             if use_apparent_size {
                 Some((
@@ -43,6 +49,7 @@ pub fn get_metadata<P: AsRef<Path>>(
 pub fn get_metadata<P: AsRef<Path>>(
     path: P,
     use_apparent_size: bool,
+    follow_links: bool,
 ) -> Option<(u64, Option<InodeAndDevice>, FileTime)> {
     // On windows opening the file to get size, file ID and volume can be very
     // expensive because 1) it causes a few system calls, and more importantly 2) it can cause
@@ -142,7 +149,12 @@ pub fn get_metadata<P: AsRef<Path>>(
 
     use std::os::windows::fs::MetadataExt;
     let path = path.as_ref();
-    match path.metadata() {
+    let metadata = if follow_links {
+        path.metadata()
+    } else {
+        path.symlink_metadata()
+    };
+    match metadata {
         Ok(ref md) => {
             const FILE_ATTRIBUTE_ARCHIVE: u32 = 0x20;
             const FILE_ATTRIBUTE_READONLY: u32 = 0x01;


### PR DESCRIPTION
# Background

Previously, the function get_metadata in platform.rs used `fs::metadata` which follows symbolic links and returns metadata for the target file. This caused issues https://github.com/bootandy/dust/issues/421: **du / dust disagreement**  when trying to determine properties of the symbolic link itself   

# Full Changelogs

- fix: retrieve metadata for symbolic links without following them

# Issue Reference

du / dust disagreement： https://github.com/bootandy/dust/issues/421

# Test Result

cargo test command output

![image](https://github.com/user-attachments/assets/c3bb1e88-8475-4e33-99a7-5e542569aa72)

du -s output vs cargo run -- -ok /home/shirley/code/python/official/superset/superset-frontend

![image](https://github.com/user-attachments/assets/cc8d9007-a484-4bc7-9df9-c75a527b5f3f)

du -s -L output vs cargo run -- -ok -L /home/shirley/code/python/official/superset/superset-frontend

![image](https://github.com/user-attachments/assets/df64cb9a-d601-4e02-af51-bc30a57b6366)

while use dust v1.0.0 command,
![image](https://github.com/user-attachments/assets/4bd80680-f768-4ff9-833a-fe66bd131027)

![image](https://github.com/user-attachments/assets/3825637f-80a7-471f-aedc-7b3cc91a3fd6)

The output shows that dust v1.0.0 produces the same results regardless of whether the -L parameter is used. That disagrees with du command.

# performance test results

![image](https://github.com/user-attachments/assets/46e8ba96-9913-4ddd-8e10-54d36960eb75)
![image](https://github.com/user-attachments/assets/4535537f-ee9f-48b7-8885-4ae79689896c)

![image](https://github.com/user-attachments/assets/c8199c74-06e1-4d80-9819-112deb0a1579)
![image](https://github.com/user-attachments/assets/491f9a41-2b99-4a2b-aed5-10b807cb3306)
