### PR TITLE
fix: 64-bit atomics for platforms with no 64-bit atomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ sysinfo = "0.27"
 ctrlc = "3.4"
 chrono = "0.4"
 
+[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
+portable-atomic = "1.4"
+
 [target.'cfg(windows)'.dependencies]
 winapi-util = "0.1"
 filesize = "0.2.0"

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -3,13 +3,18 @@ use std::{
     io::Write,
     path::Path,
     sync::{
-        atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering},
+        atomic::{AtomicU8, AtomicUsize, Ordering},
         mpsc::{self, RecvTimeoutError, Sender},
         Arc, RwLock,
     },
     thread::JoinHandle,
     time::Duration,
 };
+
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
 
 use crate::display::human_readable_number;
 


### PR DESCRIPTION
`AtomicU64` cannot be used on platforms without 64-bit atomics, such as armel. This PR adds a dependency on the `portable-atomic` crate for those platforms, using the type of the same name defined in it. It introduces no changes for all other platforms (in particular, those on which dust currently builds are unchanged). I tested that this patch cross-builds to armel, and that all tests pass in an emulated armel environment.