### PR TITLE
feat: use pre-commit hooks to standardize commit messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: cargo-check
+        stages: [commit]
+      - id: fmt
+        stages: [commit]
+      - id: clippy
+        args: [--all-targets, --all-features]
+        stages: [commit]


### PR DESCRIPTION
Use pre-commit hooks to do more checks and optimize submission information before submission.

# How to use
```
pip3 install pre-commit
pre-commit install
````