### PR TITLE
Docs: update sample config.toml

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -25,4 +25,4 @@ skip-total=true
 ignore-hidden=true
 
 # print sizes in powers of 1000 (e.g., 1.1G)
-iso=true
+output-format="si"


### PR DESCRIPTION
Update `iso=true` in the config.toml to `output-format="si"` to fix issue: https://github.com/bootandy/dust/issues/430