### PR TITLE
fix: man-page and completions missing in debian package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,16 @@ assets = [
     "usr/share/doc/du-dust/README",
     "644",
   ],
+  [
+    "man-page/dust.1",
+    "usr/share/man/man1/dust.1",
+    "644",
+  ],
+  [
+    "completions/dust.bash",
+    "usr/share/bash-completion/completions/dust",
+    "644",
+  ],
 ]
 extended-description = """\
 Dust is meant to give you an instant overview of which directories are using


### PR DESCRIPTION
solve issue: https://github.com/bootandy/dust/issues/432
fix: man-page and completions missing in debian package