### PR TITLE
refactor: simplify `get_height_of_terminal()` and `get_width...`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,23 +81,19 @@ fn should_init_color(no_color: bool, force_color: bool) -> bool {
 }
 
 fn get_height_of_terminal() -> usize {
-    // Simplify once https://github.com/eminence/terminal-size/pull/41 is
-    // merged
     terminal_size()
         // Windows CI runners detect a terminal height of 0
-        .map(|(_, Height(h))| max(h as usize, DEFAULT_NUMBER_OF_LINES))
+        .map(|(_, Height(h))| max(h.into(), DEFAULT_NUMBER_OF_LINES))
         .unwrap_or(DEFAULT_NUMBER_OF_LINES)
         - 10
 }
 
 fn get_width_of_terminal() -> usize {
-    // Simplify once https://github.com/eminence/terminal-size/pull/41 is
-    // merged
     terminal_size()
         .map(|(Width(w), _)| match cfg!(windows) {
             // Windows CI runners detect a very low terminal width
-            true => max(w as usize, DEFAULT_TERMINAL_WIDTH),
-            false => w as usize,
+            true => max(w.into(), DEFAULT_TERMINAL_WIDTH),
+            false => w.into(),
         })
         .unwrap_or(DEFAULT_TERMINAL_WIDTH)
 }


### PR DESCRIPTION
The https://github.com/eminence/terminal-size/pull/41 PR mentioned in comments of `get_(height|width)_of_terminal()` (added by https://github.com/bootandy/dust/commit/c36ca33fe973657002905bbdb77c639ac3c006f0)

https://github.com/bootandy/dust/blob/b63608604a768386506b6736f56092583e8fa5a0/src/main.rs#L83-L91

has been merged and shipped since `terminal-size` [v0.2.2](https://github.com/eminence/terminal-size/releases/tag/v0.2.2). As we're using `terminal-size` v0.2.6 now, it's time to simplify them.

https://github.com/bootandy/dust/blob/38c4d237321dcdb4f71f1918ec1cb473ed66655b/Cargo.lock#L766-L768

Not sure if I made it to the most simplified form, as I can hardly speak Rust.

cc @Lucretiel