### PR TITLE
POC: deleted files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ directories = "4"
 sysinfo = "0.27"
 ctrlc = "3.4"
 chrono = "0.4"
+procfs = { version = "0.17.0", default-features = false }
 
 [target.'cfg(not(target_has_atomic = "64"))'.dependencies]
 portable-atomic = "1.4"

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -10,7 +10,7 @@ fn get_block_size() -> u64 {
     512
 }
 
-type InodeAndDevice = (u64, u64);
+pub(crate) type InodeAndDevice = (u64, u64);
 type FileTime = (i64, i64, i64);
 
 #[cfg(target_family = "unix")]


### PR DESCRIPTION
Hi,

This is a quick and dirty POC for https://github.com/bootandy/dust/issues/444

Here are the changes

* I used [procfs](https://github.com/eminence/procfs) to walk the processes under `/proc/`, but we can do this manually if you don't want to add a new dependency. The function to list files is `get_deleted_files`
* I added a function to modify the node tree: `insert_deleted_file_in_node`, maybe it could be merged with `build_node`
* The handling of the deleted files is done in `walk_it`
* I also made `InodeAndDevice` `pub(crate)` and used it to replace a few `(u64, u64)`

The drawbacks:

* There is an edge case with multiple deleted hardlinks with different paths: in this case, only the 1st file will be listed
* I only handle the file size for now (no filecount, filetime...), also `WalkData` is not used (no regex, ignore_dir...)
* I hardcoded the flag to handle the deleted files

On the bright side, there is no change (performance or inner working) if we set `handle_deleted_files` to false

Let me know what you think about it