### PR TITLE
fix typo Operator

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -45,6 +45,9 @@ jobs:
           override: true
           profile: minimal # minimal component installation (ie, no documentation)
           components: rustfmt, clippy
+      - name: Install wget for Windows
+        if: matrix.job.os == 'windows-latest'
+        run: choco install wget --no-progress
       - name: typos-action
         uses: crate-ci/typos@v1.28.4
       - name: "`fmt` testing"

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -45,6 +45,8 @@ jobs:
           override: true
           profile: minimal # minimal component installation (ie, no documentation)
           components: rustfmt, clippy
+      - name: typos-action
+        uses: crate-ci/typos@v1.28.4
       - name: "`fmt` testing"
         if: steps.vars.outputs.JOB_DO_FORMAT_TESTING
         uses: actions-rs/cargo@v1

--- a/src/config.rs
+++ b/src/config.rs
@@ -231,7 +231,7 @@ fn convert_min_size(input: &str) -> Option<usize> {
                 match number_format {
                     Some((multiple, _)) => Some(parsed_digits * (multiple as usize)),
                     None => {
-                        if letters.eq("") {
+                        if letters.is_empty() {
                             Some(parsed_digits)
                         } else {
                             eprintln!("Ignoring invalid min-size: {input}");

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use std::io::IsTerminal;
 use std::path::Path;
 use std::path::PathBuf;
 
-use crate::dir_walker::Operater;
+use crate::dir_walker::Operator;
 use crate::display::get_number_format;
 
 pub static DAY_SECONDS: i64 = 24 * 60 * 60;
@@ -160,21 +160,21 @@ impl Config {
         Some(true) == self.output_json || options.get_flag("output_json")
     }
 
-    pub fn get_modified_time_operator(&self, options: &ArgMatches) -> Option<(Operater, i64)> {
+    pub fn get_modified_time_operator(&self, options: &ArgMatches) -> Option<(Operator, i64)> {
         get_filter_time_operator(
             options.get_one::<String>("mtime"),
             get_current_date_epoch_seconds(),
         )
     }
 
-    pub fn get_accessed_time_operator(&self, options: &ArgMatches) -> Option<(Operater, i64)> {
+    pub fn get_accessed_time_operator(&self, options: &ArgMatches) -> Option<(Operator, i64)> {
         get_filter_time_operator(
             options.get_one::<String>("atime"),
             get_current_date_epoch_seconds(),
         )
     }
 
-    pub fn get_changed_time_operator(&self, options: &ArgMatches) -> Option<(Operater, i64)> {
+    pub fn get_changed_time_operator(&self, options: &ArgMatches) -> Option<(Operator, i64)> {
         get_filter_time_operator(
             options.get_one::<String>("ctime"),
             get_current_date_epoch_seconds(),
@@ -183,7 +183,7 @@ impl Config {
 }
 
 fn get_current_date_epoch_seconds() -> i64 {
-    // calcurate current date epoch seconds
+    // calculate current date epoch seconds
     let now = Local::now();
     let current_date = now.date_naive();
 
@@ -197,7 +197,7 @@ fn get_current_date_epoch_seconds() -> i64 {
 fn get_filter_time_operator(
     option_value: Option<&String>,
     current_date_epoch_seconds: i64,
-) -> Option<(Operater, i64)> {
+) -> Option<(Operator, i64)> {
     match option_value {
         Some(val) => {
             let time = current_date_epoch_seconds
@@ -207,9 +207,9 @@ fn get_filter_time_operator(
                     .abs()
                     * DAY_SECONDS;
             match val.chars().next().expect("Value should not be empty") {
-                '+' => Some((Operater::LessThan, time - DAY_SECONDS)),
-                '-' => Some((Operater::GreaterThan, time)),
-                _ => Some((Operater::Equal, time - DAY_SECONDS)),
+                '+' => Some((Operator::LessThan, time - DAY_SECONDS)),
+                '-' => Some((Operator::GreaterThan, time)),
+                _ => Some((Operator::Equal, time - DAY_SECONDS)),
             }
         }
         None => None,

--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -25,7 +25,7 @@ use crate::node::FileTime;
 use crate::platform::get_metadata;
 
 #[derive(Debug)]
-pub enum Operater {
+pub enum Operator {
     Equal = 0,
     LessThan = 1,
     GreaterThan = 2,
@@ -36,9 +36,9 @@ pub struct WalkData<'a> {
     pub filter_regex: &'a [Regex],
     pub invert_filter_regex: &'a [Regex],
     pub allowed_filesystems: HashSet<u64>,
-    pub filter_modified_time: Option<(Operater, i64)>,
-    pub filter_accessed_time: Option<(Operater, i64)>,
-    pub filter_changed_time: Option<(Operater, i64)>,
+    pub filter_modified_time: Option<(Operator, i64)>,
+    pub filter_accessed_time: Option<(Operator, i64)>,
+    pub filter_changed_time: Option<(Operator, i64)>,
     pub use_apparent_size: bool,
     pub by_filecount: bool,
     pub by_filetime: &'a Option<FileTime>,
@@ -300,9 +300,9 @@ mod tests {
             filter_regex: &[],
             invert_filter_regex: &[],
             allowed_filesystems: HashSet::new(),
-            filter_modified_time: Some((Operater::GreaterThan, 0)),
-            filter_accessed_time: Some((Operater::GreaterThan, 0)),
-            filter_changed_time: Some((Operater::GreaterThan, 0)),
+            filter_modified_time: Some((Operator::GreaterThan, 0)),
+            filter_accessed_time: Some((Operator::GreaterThan, 0)),
+            filter_changed_time: Some((Operator::GreaterThan, 0)),
             use_apparent_size,
             by_filecount: false,
             by_filetime: &None,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::config::DAY_SECONDS;
 
-use crate::dir_walker::Operater;
+use crate::dir_walker::Operator;
 use crate::platform;
 use regex::Regex;
 
@@ -78,16 +78,16 @@ pub fn is_filtered_out_due_to_regex(filter_regex: &[Regex], dir: &Path) -> bool 
 }
 
 pub fn is_filtered_out_due_to_file_time(
-    filter_time: &Option<(Operater, i64)>,
+    filter_time: &Option<(Operator, i64)>,
     actual_time: i64,
 ) -> bool {
     match filter_time {
         None => false,
-        Some((Operater::Equal, bound_time)) => {
+        Some((Operator::Equal, bound_time)) => {
             !(actual_time >= *bound_time && actual_time < *bound_time + DAY_SECONDS)
         }
-        Some((Operater::GreaterThan, bound_time)) => actual_time < *bound_time,
-        Some((Operater::LessThan, bound_time)) => actual_time > *bound_time,
+        Some((Operator::GreaterThan, bound_time)) => actual_time < *bound_time,
+        Some((Operator::LessThan, bound_time)) => actual_time > *bound_time,
     }
 }
 


### PR DESCRIPTION
Hello

This PR

- fix the typo `Operator`
  - Fixed with `typos -w` https://github.com/crate-ci/typos
- add typos to the CI/CD using typos actions - https://github.com/marketplace/actions/typos-action


