### PR TITLE
fix: Handle Interrupted Error

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -78,6 +78,7 @@ pub struct RuntimeErrors {
     pub no_permissions: HashSet<String>,
     pub file_not_found: HashSet<String>,
     pub unknown_error: HashSet<String>,
+    pub interrupted_error: i32,
     pub abort: bool,
 }
 


### PR DESCRIPTION
Rust may throw Interrupted errors while scanning filesystem. These may be retried:
https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.Interrupted

Fixes:
https://github.com/bootandy/dust/issues/420