### PR TITLE
fix: Support absolute path with `-X` option

### DIFF
--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -132,19 +132,14 @@ fn is_ignored_path(path: &Path, walk_data: &WalkData) -> bool {
     }
 
     // Entry is inside an ignored absolute path
+    // Absolute paths should be canonicalized before being added to `WalkData.ignore_directories`
     for ignored_path in walk_data.ignore_directories.iter() {
         if !ignored_path.is_absolute() {
             continue;
         }
-        match std::fs::canonicalize(ignored_path) {
-            Ok(absolute_ignored_path) => {
-                let absolute_entry_path =
-                    std::fs::canonicalize(path).unwrap_or_default();
-                if absolute_entry_path.starts_with(absolute_ignored_path) {
-                    return true;
-                }
-            }
-            Err(_) => continue,
+        let absolute_entry_path = std::fs::canonicalize(path).unwrap_or_default();
+        if absolute_entry_path.starts_with(ignored_path) {
+            return true;
         }
     }
 

--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -177,6 +177,9 @@ fn ignore_file(entry: &DirEntry, walk_data: &WalkData) -> bool {
 
     // Entry is inside an ignored absolute path
     for ignored_path in walk_data.ignore_directories.iter() {
+        if !ignored_path.is_absolute() {
+            continue;
+        }
         match std::fs::canonicalize(ignored_path) {
             Ok(absolute_ignored_path) => {
                 let absolute_entry_path =

--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -175,6 +175,20 @@ fn ignore_file(entry: &DirEntry, walk_data: &WalkData) -> bool {
         return true;
     }
 
+    // Entry is inside an ignored absolute path
+    for ignored_path in walk_data.ignore_directories.iter() {
+        match std::fs::canonicalize(ignored_path) {
+            Ok(absolute_ignored_path) => {
+                let absolute_entry_path =
+                    std::fs::canonicalize(&entry.path()).unwrap_or(PathBuf::new());
+                if absolute_entry_path.starts_with(absolute_ignored_path) {
+                    return true;
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+
     (is_dot_file && walk_data.ignore_hidden) || is_ignored_path
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 use sysinfo::{System, SystemExt};
+use utils::canonicalize_absolute_path;
 
 use self::display::draw_it;
 use config::get_config;
@@ -198,6 +199,7 @@ fn main() {
         Some(values) => values
             .map(|v| v.as_str())
             .map(PathBuf::from)
+            .map(canonicalize_absolute_path)
             .collect::<Vec<PathBuf>>(),
         None => vec![],
     };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -67,6 +67,18 @@ pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
     path.as_ref().components().collect()
 }
 
+// Canonicalize the path only if it is an absolute path
+pub fn canonicalize_absolute_path(path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        match std::fs::canonicalize(&path) {
+            Ok(canonicalized_path) => canonicalized_path,
+            Err(_) => path,
+        }
+    } else {
+        path
+    }
+}
+
 pub fn is_filtered_out_due_to_regex(filter_regex: &[Regex], dir: &Path) -> bool {
     if filter_regex.is_empty() {
         false

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -69,13 +69,12 @@ pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
 
 // Canonicalize the path only if it is an absolute path
 pub fn canonicalize_absolute_path(path: PathBuf) -> PathBuf {
-    if path.is_absolute() {
-        match std::fs::canonicalize(&path) {
-            Ok(canonicalized_path) => canonicalized_path,
-            Err(_) => path,
-        }
-    } else {
-        path
+    if !path.is_absolute() {
+        return path;
+    }
+    match std::fs::canonicalize(&path) {
+        Ok(canonicalized_path) => canonicalized_path,
+        Err(_) => path,
     }
 }
 


### PR DESCRIPTION
Allow excluding any directory or file by absolute path using the `-X` option.

The proposed change for the `ignore_file` function checks whether the file's absolute path representation starts with any of the absolute path representations of ignored directories. Any file inside an ignored folder should have a common path with the ignored directory.

Fixes: #471