### PR TITLE
feat: Abort immedietly when ^C is received.

### DIFF
--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -206,10 +206,6 @@ fn walk(dir: PathBuf, walk_data: &WalkData, depth: usize) -> Option<Node> {
     let prog_data = &walk_data.progress_data;
     let errors = &walk_data.errors;
 
-    if errors.lock().unwrap().abort {
-        return None;
-    }
-
     let children = if dir.is_dir() {
         let read_dir = fs::read_dir(&dir);
         match read_dir {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -79,7 +79,6 @@ pub struct RuntimeErrors {
     pub file_not_found: HashSet<String>,
     pub unknown_error: HashSet<String>,
     pub interrupted_error: i32,
-    pub abort: bool,
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
Previously, we attempted to perform a clean shutdown, which could take a significant period of time on slow filesystems. This commit changes the shutdown logic to unconditionally abort immediately when ^C is received by the program.

This PR resolves #477.