### PR TITLE
fix: status mesages go to stderr not stdout

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,6 @@ use clap::ArgMatches;
 use config_file::FromConfigFile;
 use regex::Regex;
 use serde::Deserialize;
-use std::io::IsTerminal;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -54,9 +53,7 @@ impl Config {
         Some(true) == self.force_colors || options.get_flag("force_colors")
     }
     pub fn get_disable_progress(&self, options: &ArgMatches) -> bool {
-        Some(true) == self.disable_progress
-            || options.get_flag("disable_progress")
-            || !std::io::stdout().is_terminal()
+        Some(true) == self.disable_progress || options.get_flag("disable_progress")
     }
     pub fn get_apparent_size(&self, options: &ArgMatches) -> bool {
         Some(true) == self.display_apparent_size || options.get_flag("display_apparent_size")

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -10,6 +10,9 @@ use std::str;
 
 fn build_command<T: AsRef<OsStr>>(command_args: Vec<T>) -> String {
     let mut cmd = &mut Command::cargo_bin("dust").unwrap();
+    // Hide progress bar
+    cmd = cmd.arg("-P");
+
     for p in command_args {
         cmd = cmd.arg(p);
     }


### PR DESCRIPTION
Progress spinner and status line are written to stderr instead of stdout.

No longer any need to detect if stdout is being redirected.