### PR TITLE
Fix miscalculation of NTFS mount file sizes inside WSL

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -42,9 +42,11 @@ pub fn get_metadata<P: AsRef<Path>>(
             // Related: https://github.com/bootandy/dust/issues/295
             let blksize = md.blksize();
             let target_size = file_size.div_ceil(blksize) * blksize;
-            // At least EXT4 can pre-allocate an extra block for a file
-            let max_size = target_size + blksize;
             let reported_size = md.blocks() * get_block_size();
+
+            // File systems can pre-allocate more space for a file than what would be necessary
+            let pre_allocation_buffer = blksize * 65536;
+            let max_size = target_size + pre_allocation_buffer;
             let allocated_size = if reported_size > max_size {
                 target_size
             } else {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -41,7 +41,7 @@ pub fn get_metadata<P: AsRef<Path>>(
             // file should occupy based on the file system I/O block size (blksize).
             // Related: https://github.com/bootandy/dust/issues/295
             let blksize = md.blksize();
-            let target_size = ((file_size + blksize - 1) / blksize) * blksize;
+            let target_size = file_size.div_ceil(blksize) * blksize;
             // At least EXT4 can pre-allocate an extra block for a file
             let max_size = target_size + blksize;
             let reported_size = md.blocks() * get_block_size();

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -45,7 +45,11 @@ pub fn get_metadata<P: AsRef<Path>>(
             // At least EXT4 can pre-allocate an extra block for a file
             let max_size = target_size + blksize;
             let reported_size = md.blocks() * get_block_size();
-            let allocated_size = reported_size.min(max_size);
+            let allocated_size = if reported_size > max_size {
+                target_size
+            } else {
+                reported_size
+            };
             Some((
                 allocated_size,
                 Some((md.ino(), md.dev())),

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -40,7 +40,9 @@ pub fn get_metadata<P: AsRef<Path>>(
                 // file should occupy based on the file system I/O block size (blksize).
                 // Related: https://github.com/bootandy/dust/issues/295
                 let blksize = md.blksize();
-                let max_size = ((file_size + blksize - 1) / blksize) * blksize;
+                let target_size = ((file_size + blksize - 1) / blksize) * blksize;
+                // At least EXT4 can pre-allocate an extra block for a file
+                let max_size = target_size + blksize;
                 let reported_size = md.blocks() * get_block_size();
                 let allocated_size = reported_size.min(max_size);
                 Some((

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -29,28 +29,28 @@ pub fn get_metadata<P: AsRef<Path>>(
         Ok(md) => {
             let file_size = md.len();
             if use_apparent_size {
-                Some((
+                return Some((
                     file_size,
                     Some((md.ino(), md.dev())),
                     (md.mtime(), md.atime(), md.ctime()),
-                ))
-            } else {
-                // On NTFS mounts, the reported block count can be unexpectedly large.
-                // To avoid overestimating disk usage, cap the allocated size to what the
-                // file should occupy based on the file system I/O block size (blksize).
-                // Related: https://github.com/bootandy/dust/issues/295
-                let blksize = md.blksize();
-                let target_size = ((file_size + blksize - 1) / blksize) * blksize;
-                // At least EXT4 can pre-allocate an extra block for a file
-                let max_size = target_size + blksize;
-                let reported_size = md.blocks() * get_block_size();
-                let allocated_size = reported_size.min(max_size);
-                Some((
-                    allocated_size,
-                    Some((md.ino(), md.dev())),
-                    (md.mtime(), md.atime(), md.ctime()),
-                ))
+                ));
             }
+
+            // On NTFS mounts, the reported block count can be unexpectedly large.
+            // To avoid overestimating disk usage, cap the allocated size to what the
+            // file should occupy based on the file system I/O block size (blksize).
+            // Related: https://github.com/bootandy/dust/issues/295
+            let blksize = md.blksize();
+            let target_size = ((file_size + blksize - 1) / blksize) * blksize;
+            // At least EXT4 can pre-allocate an extra block for a file
+            let max_size = target_size + blksize;
+            let reported_size = md.blocks() * get_block_size();
+            let allocated_size = reported_size.min(max_size);
+            Some((
+                allocated_size,
+                Some((md.ino(), md.dev())),
+                (md.mtime(), md.atime(), md.ctime()),
+            ))
         }
         Err(_e) => None,
     }


### PR DESCRIPTION
The [std::fs::Metadata](https://doc.rust-lang.org/beta/std/fs/struct.Metadata.html) struct sometimes contains incorrect information on how many blocks are allocated to a certain file on an NTFS mount. When that happens, the struct could have an unfathomably large block count that is unrelated to the file's real size.

The proposed fix determines how much space could be allocated to a certain file using `md.blksize()`. As far as I know, a file should only have up to one extra operating system block or page allocated for it, typically an extra 4 KB at most. The fixed code uses the same calculation as before by default (`reported_size = md.blocks() * get_block_size()`), but uses the `max_size` when it is smaller than the `reported_size`. The `max_size` should be smaller than the `reported_size` only when the metadata reports too many blocks or when the file system pre-allocates more data for a file than is necessary based on the OS page size.

Here is an example of how the current version of `dust` calculates that my _C:\Users_ folder contains 9057 PB of data, whereas the proposed fixed version shows the correct amount of data, or at least very close to it.

```bash
$ dust /mnt/c/Users/ -b
...
9057P ┌─┴ Users
$ cargo run --release -- /mnt/c/Users/ -b
...
113G ┌─┴ Users
```

fixes #295