### PR TITLE
fix: dir_walker interrupted error

### DIFF
--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -305,7 +305,9 @@ fn handle_error_and_retry(failed: &Error, dir: &Path, walk_data: &WalkData) -> b
         }
         std::io::ErrorKind::Interrupted => {
             editable_error.interrupted_error += 1;
-            if editable_error.interrupted_error > 3 {
+            // This does happen on some systems. It was set to 3 but sometimes dust runs would exceed this
+            // However, if there is no limit this results in infinite retrys and dust never finishes
+            if editable_error.interrupted_error > 999 {
                 panic!("Multiple Interrupted Errors occurred while scanning filesystem. Aborting");
             } else {
                 return true;


### PR DESCRIPTION
Ignore and continue if we get many interrupted errors instead of panicing on 3.

This is from user feedback who reported occasional panics from too many interrupted errors

https://github.com/bootandy/dust/issues/495#issuecomment-3026673312