### PR TITLE
Fix multi-paths output when `depth` is `0`

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -46,10 +46,11 @@ pub fn get_biggest(
 
             let nodes = handle_duplicate_top_level_names(top_level_nodes, display_data.short_paths);
             root = total_node_builder(size, nodes);
+            heap = always_add_children(&display_data, &root, heap);
         } else {
             root = top_level_nodes.into_iter().next().unwrap();
+            heap = add_children(&display_data, &root, heap);
         }
-        heap = add_children(&display_data, &root, heap);
     }
 
     fill_remaining_lines(heap, &root, display_data, keep_collapsed)


### PR DESCRIPTION
Today I met a small bug introduced at 74ffd7890194bf850b75dc4ff0fd72ce358c8a00 . When I run `dust -d0 -c -B path1 path2 ...`, the previous released version prints something like:

```plaintext
12K   ┌── test_dir │                                                 ██████████████████████████ │  33%
24K   ├── test_dir2│                        ███████████████████████████████████████████████████ │  67%
36K ┌─┴ (total)    │███████████████████████████████████████████████████████████████████████████ │ 100%
```

Current latest version turns to display something like (only total, no other lines):

```plaintext
36K ┌── (total)│███████████████████████████████████████████████████████████████████████████████ │ 100%
```

The bug comes from 74ffd7890194bf850b75dc4ff0fd72ce358c8a00 , which seems to accidently remove the line:

```rs
heap = always_add_children(&display_data, &root, heap);
```

and let the program fall to

```rs
heap = add_children(&display_data, &root, heap);
```

and finally lead to regression.