### PR TITLE
fix: dont format filecount when output is set to json

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -439,6 +439,9 @@ pub fn get_number_format(output_str: &str) -> Option<(u64, char)> {
 }
 
 pub fn human_readable_number(size: u64, output_str: &str) -> String {
+    if output_str == "count" {
+        return size.to_string();
+    };
     match get_number_format(output_str) {
         Some((x, u)) => {
             format!("{}{}", (size / x), u)
@@ -537,6 +540,13 @@ mod tests {
 
         let s = format_string(&n, indent, percent_bar, is_biggest, &data);
         assert_eq!(s, "short               3  4.0K 100%");
+    }
+
+    #[test]
+    fn test_machine_readable_filecount() {
+        assert_eq!(human_readable_number(1, "count"), "1");
+        assert_eq!(human_readable_number(1000, "count"), "1000");
+        assert_eq!(human_readable_number(1024, "count"), "1024");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,7 +319,11 @@ fn print_output(
 
     if config.get_output_json(&options) {
         OUTPUT_TYPE.with(|wrapped| {
-            wrapped.replace(output_format);
+            if by_filecount {
+                wrapped.replace("count".to_string());
+            } else {
+                wrapped.replace(output_format);
+            }
         });
         println!("{}", serde_json::to_string(&tree).unwrap());
     } else {


### PR DESCRIPTION
when calculating filecount the count number is formatted as filesize, this pr fixes that

didnt format the number with a comma because json is usually read by other programs not humans

also added tests that basically return the same number as a string

## before vs after
<img width="375" height="250" alt="Screenshot_20251010_160715_grim" src="https://github.com/user-attachments/assets/a069a597-2a53-44da-ad0c-92b8629b4dce" /> <img width="" height="250" alt="Screenshot_20251010_160848_grim" src="https://github.com/user-attachments/assets/52461ef8-d5b6-414c-ae3d-940d4d15c0fc" />