### PR TITLE
tests: Update assert_cmd

### DIFF
--- a/tests/test_exact_output.rs
+++ b/tests/test_exact_output.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::{Command, cargo_bin_cmd};
 use std::ffi::OsStr;
 use std::process::Output;
 use std::sync::Once;
@@ -61,11 +61,11 @@ fn initialize() {
 
 fn run_cmd<T: AsRef<OsStr>>(command_args: &[T]) -> Output {
     initialize();
-    let mut to_run = &mut Command::cargo_bin("dust").unwrap();
+    let mut to_run = cargo_bin_cmd!("dust");
     // Hide progress bar
     to_run.arg("-P");
     for p in command_args {
-        to_run = to_run.arg(p);
+        to_run.arg(p);
     }
     to_run.unwrap()
 }

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::cargo_bin_cmd;
 use std::ffi::OsStr;
 use std::str;
 
@@ -9,17 +9,16 @@ use std::str;
  */
 
 fn build_command<T: AsRef<OsStr>>(command_args: Vec<T>) -> String {
-    let mut cmd = &mut Command::cargo_bin("dust").unwrap();
+    let mut cmd = cargo_bin_cmd!("dust");
+
     // Hide progress bar
-    cmd = cmd.arg("-P");
+    cmd.arg("-P");
 
     for p in command_args {
-        cmd = cmd.arg(p);
+        cmd.arg(p);
     }
     let finished = &cmd.unwrap();
-    let stderr = str::from_utf8(&finished.stderr).unwrap();
-    assert_eq!(stderr, "");
-
+    assert_eq!(str::from_utf8(&finished.stderr).unwrap(), "");
     str::from_utf8(&finished.stdout).unwrap().into()
 }
 
@@ -126,7 +125,7 @@ pub fn test_files0_from_flag_file() {
 
 #[test]
 pub fn test_files_from_flag_stdin() {
-    let mut cmd = Command::cargo_bin("dust").unwrap();
+    let mut cmd = cargo_bin_cmd!("dust");
     cmd.arg("-P").arg("--files-from").arg("-");
     let input = b"tests/test_dir_files_from/a_file\ntests/test_dir_files_from/hello_file\n";
     cmd.write_stdin(input.as_ref());
@@ -140,7 +139,7 @@ pub fn test_files_from_flag_stdin() {
 
 #[test]
 pub fn test_files0_from_flag_stdin() {
-    let mut cmd = Command::cargo_bin("dust").unwrap();
+    let mut cmd = cargo_bin_cmd!("dust");
     cmd.arg("-P").arg("--files0-from").arg("-");
     let input = b"tests/test_dir_files_from/a_file\0tests/test_dir_files_from/hello_file\0";
     cmd.write_stdin(input.as_ref());
@@ -154,7 +153,7 @@ pub fn test_files0_from_flag_stdin() {
 
 #[test]
 pub fn test_with_bad_param() {
-    let mut cmd = Command::cargo_bin("dust").unwrap();
+    let mut cmd = cargo_bin_cmd!("dust");
     cmd.arg("-P").arg("bad_place");
     let output_error = cmd.unwrap_err();
     let result = output_error.as_output().unwrap();

--- a/tests/tests_symlinks.rs
+++ b/tests/tests_symlinks.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::{Command, cargo_bin_cmd};
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
@@ -44,7 +44,7 @@ pub fn test_soft_sym_link() {
     let b = format!(" ┌── {}", file_path_s);
     let a = format!("─┴ {}", dir_s);
 
-    let mut cmd = Command::cargo_bin("dust").unwrap();
+    let mut cmd = cargo_bin_cmd!("dust");
     // Mac test runners create long filenames in tmp directories
     let output = cmd
         .args(["-p", "-c", "-s", "-w", "999", dir_s])
@@ -72,7 +72,7 @@ pub fn test_hard_sym_link() {
     let file_output = format!(" ┌── {}", file_path_s);
     let dirs_output = format!("─┴ {}", dir_s);
 
-    let mut cmd = Command::cargo_bin("dust").unwrap();
+    let mut cmd = cargo_bin_cmd!("dust");
     // Mac test runners create long filenames in tmp directories
     let output = cmd.args(["-p", "-c", "-w", "999", dir_s]).unwrap().stdout;
 
@@ -96,7 +96,7 @@ pub fn test_hard_sym_link_no_dup_multi_arg() {
     let link_name = dir_link.path().join("the_link");
     let link_name_s = link_it(link_name, file_path_s, false);
 
-    let mut cmd = Command::cargo_bin("dust").unwrap();
+    let mut cmd = cargo_bin_cmd!("dust");
 
     // Mac test runners create long filenames in tmp directories
     let output = cmd
@@ -123,7 +123,7 @@ pub fn test_recursive_sym_link() {
     let a = format!("─┬ {}", dir_s);
     let b = format!(" └── {}", link_name_s);
 
-    let mut cmd = Command::cargo_bin("dust").unwrap();
+    let mut cmd = cargo_bin_cmd!("dust");
     let output = cmd
         .arg("-p")
         .arg("-c")


### PR DESCRIPTION
Use new cargo_bin_cmd macro. Old way of building Commands is deprecated