### PR TITLE
deps: switch from ansi_term to nu_ansi_term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,15 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -76,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -307,7 +298,6 @@ dependencies = [
 name = "du-dust"
 version = "1.2.3"
 dependencies = [
- "ansi_term",
  "assert_cmd",
  "chrono",
  "clap",
@@ -317,6 +307,7 @@ dependencies = [
  "ctrlc",
  "filesize",
  "lscolors",
+ "nu-ansi-term",
  "portable-atomic",
  "rayon",
  "regex",
@@ -344,7 +335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -493,7 +484,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -673,7 +664,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -784,7 +775,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -941,7 +932,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ lto = true
 strip = true
 
 [dependencies]
-ansi_term = "0.12"
 clap = { version = "4", features = ["derive"] }
 lscolors = "0.21"
+nu-ansi-term = "0.50"
 terminal_size = "0.4"
 unicode-width = "0.2"
 rayon = "1"

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,8 +1,8 @@
 use crate::display_node::DisplayNode;
 use crate::node::FileTime;
 
-use ansi_term::Colour::Red;
 use lscolors::{LsColors, Style};
+use nu_ansi_term::Color::Red;
 
 use unicode_width::UnicodeWidthStr;
 


### PR DESCRIPTION
nu-ansi-term is more popular than ansi-term which appears to be unmaintained