### PR TITLE
docs: fix broken snap repo reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ curl -sSfL https://raw.githubusercontent.com/bootandy/dust/refs/heads/master/ins
 
 - `snap install dust`
 
-Note: `dust` installed through `snap` can only access files stored in the `/home` directory. See daniejstriata/dust-snap#2 for more information.
+Note: `dust` installed through `snap` can only access files stored in the `/home` directory. See danie-dejager/dust-snap#2 for more information.
 
 #### [Pacstall](https://github.com/pacstall/pacstall) (Debian/Ubuntu)
 


### PR DESCRIPTION
The snap limitation reference in the README currently points to `daniejstriata/dust-snap#2`, which returns a 404.

The correct repository is `danie-dejager/dust-snap`, where issue #2 exists and contains the relevant information about snap access limitations.

**Changes:**
- README.md line 52: `daniejstriata/dust-snap#2` → `danie-dejager/dust-snap#2`

**Verification:**
- https://github.com/daniejstriata/dust-snap → 404
- https://github.com/danie-dejager/dust-snap/issues/2 → 200 ✓