### PR TITLE
ci: add riscv64 to release build matrix

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -92,6 +92,10 @@ jobs:
               use-cross: use-cross,
             }
           - {
+              os: ubuntu-24.04-riscv,
+              target: riscv64gc-unknown-linux-gnu,
+            }
+          - {
               os: ubuntu-latest,
               target: aarch64-unknown-linux-musl,
               use-cross: use-cross,


### PR DESCRIPTION
Adds riscv64gc-unknown-linux-gnu to the build matrix using native RISE riscv64 runners (ubuntu-24.04-riscv). Builds natively with cargo (no cross needed).

For personal accounts: install https://github.com/apps/rise-risc-v-runners-personal on this repository. Without it, the job stays queued with no runner.

Closes #564