### PR TITLE
fix: prevent panic on repeated EINTR errors during filesystem scanning

### DIFF
--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -304,7 +304,11 @@ fn handle_error_and_retry(failed: &Error, dir: &Path, walk_data: &WalkData) -> b
             // This does happen on some systems. It was set to 3 but sometimes dust runs would exceed this
             // However, if there is no limit this results in infinite retrys and dust never finishes
             if editable_error.interrupted_error > 999 {
-                panic!("Multiple Interrupted Errors occurred while scanning filesystem. Aborting");
+                eprintln!(
+                    "Too many Interrupted Errors occurred while scanning filesystem, skipping: {}",
+                    dir.to_string_lossy()
+                );
+                return false;
             } else {
                 return true;
             }


### PR DESCRIPTION
When dust scans filesystems that return many EINTR errors (e.g., network filesystems like NFS or FUSE-based mounts), the previous code called panic after 999 consecutive interrupts, crashing the program. Replaced the panic with a warning message on stderr and a graceful skip of the problematic directory, allowing the scan to continue with remaining accessible paths.

Changes: src/dir_walker.rs - in handle_error_and_retry(), panic replaced with eprintln warning and return false when interrupted_error exceeds 999.

All 29 unit tests and 28 integration tests pass.