### PR TITLE
fix: don't request full system info on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -440,7 +440,7 @@ fn init_rayon(stack: &Option<usize>, threads: &Option<usize>) -> rayon::ThreadPo
                 None
             } else {
                 let large_stack = usize::pow(1024, 3);
-                let mut sys = System::new_all();
+                let mut sys = System::new();
                 sys.refresh_memory();
                 // Larger stack size if possible to handle cases with lots of nested directories
                 let available = sys.available_memory();

--- a/tests/test_exact_output.rs
+++ b/tests/test_exact_output.rs
@@ -42,7 +42,7 @@ fn create_unreadable_directory() -> io::Result<()> {
         use std::fs::Permissions;
         use std::os::unix::fs::PermissionsExt;
         fs::create_dir_all(UNREADABLE_DIR_PATH)?;
-        fs::set_permissions(UNREADABLE_DIR_PATH, Permissions::from_mode(0))?;
+        fs::set_permissions(UNREADABLE_DIR_PATH, Permissions::from_mode(0o0))?;
     }
     Ok(())
 }


### PR DESCRIPTION
`init_rayon` is calling `System::new_all` which, at least on Linux, parses every single entry in /proc, issuing multiple syscalls per entry. On my system this currently amounts to ~0.5s of overhead on any invocation of `dust`.

Use `System::new` since `init_rayon` only needs `refresh_memory`.