### PR TITLE
Honor XDG_CONFIG_HOME for config discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ Usage: dust --collapse=node-modules will keep the node-modules folder collapsed 
 ## Config file
 
 Dust has a config file where the above options can be set.
-Either: `~/.config/dust/config.toml` or `~/.dust.toml`
+Either: `$XDG_CONFIG_HOME/dust/config.toml` (falling back to
+`~/.config/dust/config.toml`) or `~/.dust.toml`
 ```
 $ cat ~/.config/dust/config.toml
 reverse=true
@@ -154,5 +155,4 @@ Tools like ncdu & baobab, give you a view of directory sizes but you have no ide
 Dust will not count hard links multiple times (unless you want to `-s`).
 
 Typing `dust -n 90` will show you your 90 largest entries. `-n` is not quite like `head -n` or `tail -n`, dust is intelligent and chooses the largest entries
-
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -253,10 +253,11 @@ fn convert_min_size(input: &str) -> Option<usize> {
     }
 }
 
-fn get_config_locations(base: PathBuf) -> Vec<PathBuf> {
+fn get_config_locations(base: PathBuf, config_home: Option<PathBuf>) -> Vec<PathBuf> {
+    let config_home = config_home.unwrap_or_else(|| base.join(".config"));
     vec![
         base.join(".dust.toml"),
-        base.join(".config").join("dust").join("config.toml"),
+        config_home.join("dust").join("config.toml"),
     ]
 }
 
@@ -277,7 +278,11 @@ pub fn get_config(conf_path: Option<&String>) -> Config {
         }
         None => {
             if let Some(home) = std::env::home_dir() {
-                for path in get_config_locations(home) {
+                let config_home = std::env::var_os("XDG_CONFIG_HOME")
+                    .filter(|path| !path.is_empty() && Path::new(path).is_absolute())
+                    .map(PathBuf::from);
+
+                for path in get_config_locations(home, config_home) {
                     if path.exists()
                         && let Ok(config) = Config::from_config_file(&path)
                     {
@@ -298,6 +303,27 @@ mod tests {
     use super::*;
     use chrono::{Datelike, Timelike};
     use clap::Parser;
+
+    #[test]
+    fn config_locations_use_xdg_config_home() {
+        let home = PathBuf::from("/home/test");
+        let config_home = PathBuf::from("/tmp/config");
+
+        assert_eq!(
+            get_config_locations(home.clone(), Some(config_home)),
+            vec![
+                home.join(".dust.toml"),
+                PathBuf::from("/tmp/config/dust/config.toml"),
+            ]
+        );
+        assert_eq!(
+            get_config_locations(home.clone(), None),
+            vec![
+                home.join(".dust.toml"),
+                home.join(".config/dust/config.toml"),
+            ]
+        );
+    }
 
     #[test]
     fn test_get_current_date_epoch_seconds() {


### PR DESCRIPTION
## Summary

- resolve the default config directory from `XDG_CONFIG_HOME` when it is an absolute path
- retain `~/.dust.toml` and `~/.config/dust/config.toml` compatibility
- cover custom and fallback config locations with a unit test

## Why

Dust currently ignores `$XDG_CONFIG_HOME`, so users with a custom XDG config directory must pass `--config` on every invocation.

Closes #577

## Validation

- `cargo test --bin dust`
- `cargo test --test test_flags`
- `cargo test --test tests_symlinks`
- `cargo test --test test_exact_output -- --skip test_permission_normal --skip test_permission_flag`
- `cargo fmt --check`
- live CLI smoke with an XDG config enabling JSON output