### PR TITLE
feat: add `limit-filesystem` config file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ Either: `~/.config/dust/config.toml` or `~/.dust.toml`
 ```
 $ cat ~/.config/dust/config.toml
 reverse=true
+limit-filesystem=true
 ```
+Keys use the long flag name in kebab-case. See [config/config.toml](config/config.toml) for a fuller sample.
 
 ## Alternatives
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -24,6 +24,9 @@ skip-total=true
 # Do not display hidden files
 ignore-hidden=true
 
+# Only count files and directories on the same filesystem as the supplied directory
+limit-filesystem=true
+
 # print sizes in powers of 1000 (e.g., 1.1G)
 output-format="si"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ pub struct Config {
     pub skip_total: Option<bool>,
     pub screen_reader: Option<bool>,
     pub ignore_hidden: Option<bool>,
+    pub limit_filesystem: Option<bool>,
     pub output_format: Option<String>,
     pub min_size: Option<String>,
     pub only_dir: Option<bool>,
@@ -71,6 +72,9 @@ impl Config {
     }
     pub fn get_ignore_hidden(&self, options: &Cli) -> bool {
         Some(true) == self.ignore_hidden || options.ignore_hidden
+    }
+    pub fn get_limit_filesystem(&self, options: &Cli) -> bool {
+        Some(true) == self.limit_filesystem || options.limit_filesystem
     }
     pub fn get_full_paths(&self, options: &Cli) -> bool {
         Some(true) == self.display_full_paths || options.full_paths
@@ -368,6 +372,49 @@ mod tests {
 
     fn get_args(args: Vec<&str>) -> Cli {
         Cli::parse_from(args)
+    }
+
+    #[test]
+    fn test_get_limit_filesystem() {
+        // Neither config nor flag.
+        let c = Config::default();
+        assert!(!c.get_limit_filesystem(&get_args(vec![])));
+
+        // Flag only.
+        let c = Config::default();
+        assert!(c.get_limit_filesystem(&get_args(vec!["dust", "-x"])));
+
+        // Config only.
+        let c = Config {
+            limit_filesystem: Some(true),
+            ..Default::default()
+        };
+        assert!(c.get_limit_filesystem(&get_args(vec![])));
+
+        // Config disabled, flag still wins.
+        let c = Config {
+            limit_filesystem: Some(false),
+            ..Default::default()
+        };
+        assert!(!c.get_limit_filesystem(&get_args(vec![])));
+        assert!(c.get_limit_filesystem(&get_args(vec!["dust", "-x"])));
+    }
+
+    // Pins the config file key name ('limit-filesystem', not 'limit_filesystem')
+    // that the kebab-case rename produces - a rename would silently stop
+    // applying the user's setting.
+    #[test]
+    fn test_limit_filesystem_read_from_config_file() {
+        let file = tempfile::Builder::new()
+            .suffix(".toml")
+            .tempfile()
+            .expect("failed to create temp config file");
+        std::fs::write(file.path(), "limit-filesystem=true\n").expect("failed to write config");
+
+        let path = file.path().to_string_lossy().to_string();
+        let c = get_config(Some(&path));
+        assert_eq!(c.limit_filesystem, Some(true));
+        assert!(c.get_limit_filesystem(&get_args(vec![])));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,7 +199,7 @@ fn main() {
 
     let by_filecount = options.filecount;
     let by_filetime = config.get_filetime(&options);
-    let limit_filesystem = options.limit_filesystem;
+    let limit_filesystem = config.get_limit_filesystem(&options);
     let follow_links = options.dereference_links;
 
     let allowed_filesystems = if limit_filesystem {


### PR DESCRIPTION
Most configuration options that could be specified on the command line existed in the config file, but `limit-filesystem` was absent. Mirrors the existing patterns to add this support, along with minimal documentation changes. Adds a helpful link for new users to the sample config file as well in the README.md