### PR TITLE
Ignore empty path inputs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,10 @@ fn main() {
             Some(ref values) => values.clone(),
             None => vec![".".to_owned()],
         }
-    };
+    }
+    .into_iter()
+    .filter(|path| !path.is_empty())
+    .collect::<Vec<_>>();
 
     let summarize_file_types = options.file_types;
 

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -138,6 +138,35 @@ pub fn test_files_from_flag_stdin() {
 }
 
 #[test]
+pub fn test_files_from_ignores_empty_lines() {
+    let mut cmd = cargo_bin_cmd!("dust");
+    cmd.arg("-P").arg("--files-from").arg("-");
+    let input = b"tests/test_dir_files_from/a_file\n\ntests/test_dir_files_from/hello_file\n";
+    cmd.write_stdin(input.as_ref());
+    let finished = &cmd.unwrap();
+    let stderr = str::from_utf8(&finished.stderr).unwrap();
+    assert_eq!(stderr, "");
+    let output = str::from_utf8(&finished.stdout).unwrap();
+    assert!(output.contains("a_file"));
+    assert!(output.contains("hello_file"));
+}
+
+#[test]
+pub fn test_cli_paths_ignore_empty_arguments() {
+    let output = build_command(vec![
+        "-b",
+        "-c",
+        "-d",
+        "0",
+        "tests/test_dir_files_from/a_file",
+        "",
+        "tests/test_dir_files_from/hello_file",
+    ]);
+    assert!(output.contains("a_file"));
+    assert!(output.contains("hello_file"));
+}
+
+#[test]
 pub fn test_files0_from_flag_stdin() {
     let mut cmd = cargo_bin_cmd!("dust");
     cmd.arg("-P").arg("--files0-from").arg("-");


### PR DESCRIPTION
Fixes #585.

Empty target entries are now removed after paths are collected from direct arguments, `--files-from`, or `--files0-from`. The filter checks only for zero-length strings, so non-empty paths containing whitespace are preserved unchanged.

Added regressions for:

- blank lines in newline-delimited stdin input;
- explicit empty path arguments between valid paths.

Validation:

- `cargo test`
- `cargo fmt --check`
- `git diff --check`

`cargo clippy --all-targets -- -D warnings` remains blocked by pre-existing warnings in untouched files (`tests/test_exact_output.rs`, the existing header in `tests/test_flags.rs`, and `src/config.rs`).
