### PR TITLE
fix: don't truncate JSON output to the terminal height

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -467,4 +467,37 @@ mod tests {
         let args = get_args(vec!["dust", "--number-of-lines", "5"]);
         assert_eq!(c.get_number_of_lines(&args), Some(5));
     }
+
+    #[test]
+    fn test_get_number_of_lines_with_output_json() {
+        // Json output and no number-of-lines: main defaults this to usize::MAX.
+        let c = Config::default();
+        let args = get_args(vec!["dust", "--output-json"]);
+        assert!(c.get_output_json(&args));
+        assert_eq!(c.get_number_of_lines(&args), None);
+
+        // Json output from config and no number-of-lines.
+        let c = Config {
+            output_json: Some(true),
+            ..Default::default()
+        };
+        let args = get_args(vec![]);
+        assert!(c.get_output_json(&args));
+        assert_eq!(c.get_number_of_lines(&args), None);
+
+        // An explicit number-of-lines still wins over the json default.
+        let c = Config::default();
+        let args = get_args(vec!["dust", "--output-json", "--number-of-lines", "5"]);
+        assert!(c.get_output_json(&args));
+        assert_eq!(c.get_number_of_lines(&args), Some(5));
+
+        // A number-of-lines from the config file also wins.
+        let c = Config {
+            number_of_lines: Some(3),
+            ..Default::default()
+        };
+        let args = get_args(vec!["dust", "--output-json"]);
+        assert!(c.get_output_json(&args));
+        assert_eq!(c.get_number_of_lines(&args), Some(3));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,13 +154,14 @@ fn main() {
 
     let depth = config.get_depth(&options);
 
-    // If depth is set, then we set the default number_of_lines to be max
+    // If depth is set, or the output is json (which is not rendered to a
+    // terminal), then we set the default number_of_lines to be max
     // instead of screen height
 
     let number_of_lines = match config.get_number_of_lines(&options) {
         Some(val) => val,
         None => {
-            if depth != usize::MAX {
+            if depth != usize::MAX || config.get_output_json(&options) {
                 usize::MAX
             } else {
                 get_height_of_terminal()


### PR DESCRIPTION
Closes #597.

## The problem

`-j` defaults the node count to the terminal height, so JSON output is silently truncated to whatever happens to fit on screen:

```
# a tree of 80 directories + 80 files
dust -j            ->  21 nodes
dust -j -n 100000  -> 161 nodes
```

Nothing warns you. In a CI pipeline there's no terminal at all, and callers end up passing arbitrary magic numbers like `-n 10000000` to get a complete tree.

Terminal height is a rendering constraint; it has no meaning for a machine-readable format.

## The fix

When the output is JSON, default the node count to unlimited. This mirrors the branch immediately below it, which already does exactly this for an explicit `--depth`:

```rust
if depth != usize::MAX || config.get_output_json(&options) { usize::MAX } else { ... }
```

An explicit `-n` still wins, whether it comes from the flag or the config file — `number_of_lines` is an `Option` with no clap default, so "user asked for N" and "nobody asked" are already distinguishable. Verified:

```
dust -j                                  -> 161 nodes
dust -j -n 5                             ->   6 nodes
config file number-of-lines = 5, dust -j ->   6 nodes
dust (non-JSON)                          ->  21 lines, byte-identical to before
```

`-d`, `-b` and piped output are unaffected.

## Scope

The issue floats two proposals. This is the first one, **narrowed to the node count only** — depth still defaults exactly as before, and the `--no-limit` flag from proposal 2 isn't here either.

That narrowing matters for reading the thread: you replied *"I suppose that is reasonable. Why am I constraining the json output to the height of the terminal. ?"*, and @Malix-Labs then said *"I don't think it should be done by default for sure"* — prefaced by not having looked at the codebase. As I read it, that caveat lands on unlimited *depth* (which can explode on a large filesystem) rather than on the node count, which is why I left depth alone. Quoting both so you can judge rather than take my reading of it.

## Tests

One test added to `config.rs`'s existing test module, covering JSON-on, explicit-`-n`-wins, and JSON-off.

```
cargo build:        clean
cargo test:         31 + 8 + 31 + 4 passed, 0 failed
cargo fmt --check:  clean
cargo clippy:       2 warnings, both pre-existing in tests/
```
