### PR TITLE
feat: add mount point exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Usage: dust -r (reverse order of output)
 Usage: dust -o si/b/kb/kib/mb/mib/gb/gib (si - prints sizes in powers of 1000. Others print size in that format).
 Usage: dust -X ignore  (ignore all files and directories with the name 'ignore')
 Usage: dust -x (Only show directories on the same filesystem)
+Usage: dust --exclude-mounts (Do not descend into mount points below the supplied paths)
 Usage: dust -b (Do not show percentages or draw ASCII bars)
 Usage: dust -B (--bars-on-right - Percent bars moved to right side of screen)
 Usage: dust -i (Do not show hidden files)
@@ -149,6 +150,7 @@ Either: `$XDG_CONFIG_HOME/dust/config.toml` (falling back to
 $ cat ~/.config/dust/config.toml
 reverse=true
 limit-filesystem=true
+exclude-mounts=true
 ```
 Keys use the long flag name in kebab-case. See [config/config.toml](config/config.toml) for a fuller sample.
 

--- a/completions/_dust
+++ b/completions/_dust
@@ -77,6 +77,7 @@ m\:"last modified time"))' \
 '--dereference-links[dereference sym links - Treat sym links as directories and go into them]' \
 '-x[Only count the files and directories on the same filesystem as the supplied directory]' \
 '--limit-filesystem[Only count the files and directories on the same filesystem as the supplied directory]' \
+'--exclude-mounts[Do not descend into mount points below the supplied paths]' \
 '-s[Use file length instead of blocks]' \
 '--apparent-size[Use file length instead of blocks]' \
 '-r[Print tree upside down (biggest highest)]' \

--- a/completions/_dust.ps1
+++ b/completions/_dust.ps1
@@ -61,6 +61,7 @@ Register-ArgumentCompleter -Native -CommandName 'dust' -ScriptBlock {
             [CompletionResult]::new('--dereference-links', '--dereference-links', [CompletionResultType]::ParameterName, 'dereference sym links - Treat sym links as directories and go into them')
             [CompletionResult]::new('-x', '-x', [CompletionResultType]::ParameterName, 'Only count the files and directories on the same filesystem as the supplied directory')
             [CompletionResult]::new('--limit-filesystem', '--limit-filesystem', [CompletionResultType]::ParameterName, 'Only count the files and directories on the same filesystem as the supplied directory')
+            [CompletionResult]::new('--exclude-mounts', '--exclude-mounts', [CompletionResultType]::ParameterName, 'Do not descend into mount points below the supplied paths')
             [CompletionResult]::new('-s', '-s', [CompletionResultType]::ParameterName, 'Use file length instead of blocks')
             [CompletionResult]::new('--apparent-size', '--apparent-size', [CompletionResultType]::ParameterName, 'Use file length instead of blocks')
             [CompletionResult]::new('-r', '-r', [CompletionResultType]::ParameterName, 'Print tree upside down (biggest highest)')

--- a/completions/dust.bash
+++ b/completions/dust.bash
@@ -23,7 +23,7 @@ _dust() {
 
     case "${cmd}" in
         dust)
-            opts="-d -T -n -p -X -I -L -x -s -r -c -C -b -B -z -R -f -i -v -e -t -w -P -D -F -o -S -j -M -A -y -m -h -V --depth --threads --config --number-of-lines --full-paths --ignore-directory --ignore-all-in-file --dereference-links --limit-filesystem --apparent-size --reverse --no-colors --force-colors --dim --no-percent-bars --bars-on-right --min-size --screen-reader --skip-total --filecount --ignore-hidden --invert-filter --filter --file-types --terminal-width --no-progress --print-errors --only-dir --only-file --output-format --stack-size --output-json --mtime --atime --ctime --files0-from --files-from --collapse --filetime --help --version [PATH]..."
+            opts="-d -T -n -p -X -I -L -x -s -r -c -C -b -B -z -R -f -i -v -e -t -w -P -D -F -o -S -j -M -A -y -m -h -V --depth --threads --config --number-of-lines --full-paths --ignore-directory --ignore-all-in-file --dereference-links --limit-filesystem --exclude-mounts --apparent-size --reverse --no-colors --force-colors --dim --no-percent-bars --bars-on-right --min-size --screen-reader --skip-total --filecount --ignore-hidden --invert-filter --filter --file-types --terminal-width --no-progress --print-errors --only-dir --only-file --output-format --stack-size --output-json --mtime --atime --ctime --files0-from --files-from --collapse --filetime --help --version [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/dust.elv
+++ b/completions/dust.elv
@@ -58,6 +58,7 @@ set edit:completion:arg-completer[dust] = {|@words|
             cand --dereference-links 'dereference sym links - Treat sym links as directories and go into them'
             cand -x 'Only count the files and directories on the same filesystem as the supplied directory'
             cand --limit-filesystem 'Only count the files and directories on the same filesystem as the supplied directory'
+            cand --exclude-mounts 'Do not descend into mount points below the supplied paths'
             cand -s 'Use file length instead of blocks'
             cand --apparent-size 'Use file length instead of blocks'
             cand -r 'Print tree upside down (biggest highest)'

--- a/completions/dust.fish
+++ b/completions/dust.fish
@@ -31,6 +31,7 @@ m\t'last modified time'"
 complete -c dust -s p -l full-paths -d 'Subdirectories will not have their path shortened'
 complete -c dust -s L -l dereference-links -d 'dereference sym links - Treat sym links as directories and go into them'
 complete -c dust -s x -l limit-filesystem -d 'Only count the files and directories on the same filesystem as the supplied directory'
+complete -c dust -l exclude-mounts -d 'Do not descend into mount points below the supplied paths'
 complete -c dust -s s -l apparent-size -d 'Use file length instead of blocks'
 complete -c dust -s r -l reverse -d 'Print tree upside down (biggest highest)'
 complete -c dust -s c -l no-colors -d 'No colors will be printed (Useful for commands like: watch)'

--- a/config/config.toml
+++ b/config/config.toml
@@ -27,6 +27,9 @@ ignore-hidden=true
 # Only count files and directories on the same filesystem as the supplied directory
 limit-filesystem=true
 
+# Do not descend into mount points below the supplied paths
+exclude-mounts=true
+
 # print sizes in powers of 1000 (e.g., 1.1G)
 output-format="si"
 

--- a/man-page/dust.1
+++ b/man-page/dust.1
@@ -4,7 +4,7 @@
 .SH NAME
 Dust \- Like du but more intuitive
 .SH SYNOPSIS
-\fBdust\fR [\fB\-d\fR|\fB\-\-depth\fR] [\fB\-T\fR|\fB\-\-threads\fR] [\fB\-\-config\fR] [\fB\-n\fR|\fB\-\-number\-of\-lines\fR] [\fB\-p\fR|\fB\-\-full\-paths\fR] [\fB\-X\fR|\fB\-\-ignore\-directory\fR] [\fB\-I\fR|\fB\-\-ignore\-all\-in\-file\fR] [\fB\-L\fR|\fB\-\-dereference\-links\fR] [\fB\-x\fR|\fB\-\-limit\-filesystem\fR] [\fB\-s\fR|\fB\-\-apparent\-size\fR] [\fB\-r\fR|\fB\-\-reverse\fR] [\fB\-c\fR|\fB\-\-no\-colors\fR] [\fB\-C\fR|\fB\-\-force\-colors\fR] [\fB\-\-dim\fR] [\fB\-b\fR|\fB\-\-no\-percent\-bars\fR] [\fB\-B\fR|\fB\-\-bars\-on\-right\fR] [\fB\-z\fR|\fB\-\-min\-size\fR] [\fB\-R\fR|\fB\-\-screen\-reader\fR] [\fB\-\-skip\-total\fR] [\fB\-f\fR|\fB\-\-filecount\fR] [\fB\-i\fR|\fB\-\-ignore\-hidden\fR] [\fB\-v\fR|\fB\-\-invert\-filter\fR] [\fB\-e\fR|\fB\-\-filter\fR] [\fB\-t\fR|\fB\-\-file\-types\fR] [\fB\-w\fR|\fB\-\-terminal\-width\fR] [\fB\-P\fR|\fB\-\-no\-progress\fR] [\fB\-\-print\-errors\fR] [\fB\-D\fR|\fB\-\-only\-dir\fR] [\fB\-F\fR|\fB\-\-only\-file\fR] [\fB\-o\fR|\fB\-\-output\-format\fR] [\fB\-S\fR|\fB\-\-stack\-size\fR] [\fB\-j\fR|\fB\-\-output\-json\fR] [\fB\-M\fR|\fB\-\-mtime\fR] [\fB\-A\fR|\fB\-\-atime\fR] [\fB\-y\fR|\fB\-\-ctime\fR] [\fB\-\-files0\-from\fR] [\fB\-\-files\-from\fR] [\fB\-\-collapse\fR] [\fB\-m\fR|\fB\-\-filetime\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIPATH\fR] 
+\fBdust\fR [\fB\-d\fR|\fB\-\-depth\fR] [\fB\-T\fR|\fB\-\-threads\fR] [\fB\-\-config\fR] [\fB\-n\fR|\fB\-\-number\-of\-lines\fR] [\fB\-p\fR|\fB\-\-full\-paths\fR] [\fB\-X\fR|\fB\-\-ignore\-directory\fR] [\fB\-I\fR|\fB\-\-ignore\-all\-in\-file\fR] [\fB\-L\fR|\fB\-\-dereference\-links\fR] [\fB\-x\fR|\fB\-\-limit\-filesystem\fR] [\fB\-\-exclude\-mounts\fR] [\fB\-s\fR|\fB\-\-apparent\-size\fR] [\fB\-r\fR|\fB\-\-reverse\fR] [\fB\-c\fR|\fB\-\-no\-colors\fR] [\fB\-C\fR|\fB\-\-force\-colors\fR] [\fB\-\-dim\fR] [\fB\-b\fR|\fB\-\-no\-percent\-bars\fR] [\fB\-B\fR|\fB\-\-bars\-on\-right\fR] [\fB\-z\fR|\fB\-\-min\-size\fR] [\fB\-R\fR|\fB\-\-screen\-reader\fR] [\fB\-\-skip\-total\fR] [\fB\-f\fR|\fB\-\-filecount\fR] [\fB\-i\fR|\fB\-\-ignore\-hidden\fR] [\fB\-v\fR|\fB\-\-invert\-filter\fR] [\fB\-e\fR|\fB\-\-filter\fR] [\fB\-t\fR|\fB\-\-file\-types\fR] [\fB\-w\fR|\fB\-\-terminal\-width\fR] [\fB\-P\fR|\fB\-\-no\-progress\fR] [\fB\-\-print\-errors\fR] [\fB\-D\fR|\fB\-\-only\-dir\fR] [\fB\-F\fR|\fB\-\-only\-file\fR] [\fB\-o\fR|\fB\-\-output\-format\fR] [\fB\-S\fR|\fB\-\-stack\-size\fR] [\fB\-j\fR|\fB\-\-output\-json\fR] [\fB\-M\fR|\fB\-\-mtime\fR] [\fB\-A\fR|\fB\-\-atime\fR] [\fB\-y\fR|\fB\-\-ctime\fR] [\fB\-\-files0\-from\fR] [\fB\-\-files\-from\fR] [\fB\-\-collapse\fR] [\fB\-m\fR|\fB\-\-filetime\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIPATH\fR]
 .SH DESCRIPTION
 Like du but more intuitive
 .SH OPTIONS
@@ -35,6 +35,9 @@ dereference sym links \- Treat sym links as directories and go into them
 .TP
 \fB\-x\fR, \fB\-\-limit\-filesystem\fR
 Only count the files and directories on the same filesystem as the supplied directory
+.TP
+\fB\-\-exclude\-mounts\fR
+Do not descend into mount points below the supplied paths
 .TP
 \fB\-s\fR, \fB\-\-apparent\-size\fR
 Use file length instead of blocks

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,6 +48,10 @@ pub struct Cli {
     #[arg(short('x'), long)]
     pub limit_filesystem: bool,
 
+    /// Do not descend into mount points below the supplied paths
+    #[arg(long)]
+    pub exclude_mounts: bool,
+
     /// Use file length instead of blocks
     #[arg(short('s'), long)]
     pub apparent_size: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub screen_reader: Option<bool>,
     pub ignore_hidden: Option<bool>,
     pub limit_filesystem: Option<bool>,
+    pub exclude_mounts: Option<bool>,
     pub output_format: Option<String>,
     pub min_size: Option<String>,
     pub only_dir: Option<bool>,
@@ -76,6 +77,9 @@ impl Config {
     }
     pub fn get_limit_filesystem(&self, options: &Cli) -> bool {
         Some(true) == self.limit_filesystem || options.limit_filesystem
+    }
+    pub fn get_exclude_mounts(&self, options: &Cli) -> bool {
+        Some(true) == self.exclude_mounts || options.exclude_mounts
     }
     pub fn get_full_paths(&self, options: &Cli) -> bool {
         Some(true) == self.display_full_paths || options.full_paths
@@ -428,6 +432,33 @@ mod tests {
         };
         assert!(!c.get_limit_filesystem(&get_args(vec![])));
         assert!(c.get_limit_filesystem(&get_args(vec!["dust", "-x"])));
+    }
+
+    #[test]
+    fn test_get_exclude_mounts() {
+        let c = Config::default();
+        assert!(!c.get_exclude_mounts(&get_args(vec![])));
+        assert!(c.get_exclude_mounts(&get_args(vec!["dust", "--exclude-mounts"])));
+
+        let c = Config {
+            exclude_mounts: Some(true),
+            ..Default::default()
+        };
+        assert!(c.get_exclude_mounts(&get_args(vec![])));
+    }
+
+    #[test]
+    fn test_exclude_mounts_read_from_config_file() {
+        let file = tempfile::Builder::new()
+            .suffix(".toml")
+            .tempfile()
+            .expect("failed to create temp config file");
+        std::fs::write(file.path(), "exclude-mounts=true\n").expect("failed to write config");
+
+        let path = file.path().to_string_lossy().to_string();
+        let c = get_config(Some(&path));
+        assert_eq!(c.exclude_mounts, Some(true));
+        assert!(c.get_exclude_mounts(&get_args(vec![])));
     }
 
     // Pins the config file key name ('limit-filesystem', not 'limit_filesystem')

--- a/src/dir_walker.rs
+++ b/src/dir_walker.rs
@@ -35,6 +35,7 @@ pub enum Operator {
 
 pub struct WalkData<'a> {
     pub ignore_directories: HashSet<PathBuf>,
+    pub excluded_mounts: HashSet<PathBuf>,
     pub filter_regex: &'a [Regex],
     pub invert_filter_regex: &'a [Regex],
     pub allowed_filesystems: HashSet<u64>,
@@ -146,6 +147,10 @@ fn is_ignored_path(path: &Path, walk_data: &WalkData) -> bool {
 }
 
 fn ignore_file(entry: &DirEntry, walk_data: &WalkData) -> bool {
+    if !walk_data.excluded_mounts.is_empty() && walk_data.excluded_mounts.contains(&entry.path()) {
+        return true;
+    }
+
     if is_ignored_path(&entry.path(), walk_data) {
         return true;
     }
@@ -342,6 +347,7 @@ mod tests {
         let indicator = PIndicator::build_me();
         WalkData {
             ignore_directories: HashSet::new(),
+            excluded_mounts: HashSet::new(),
             filter_regex: &[],
             invert_filter_regex: &[],
             allowed_filesystems: HashSet::new(),
@@ -373,6 +379,22 @@ mod tests {
 
         // Second time is a duplicate - we ignore it
         assert_eq!(clean_inodes(n.clone(), &mut inodes, &walkdata), None);
+    }
+
+    #[test]
+    fn test_should_ignore_excluded_mount() {
+        let root = tempfile::tempdir().unwrap();
+        let mount_point = root.path().join("mounted");
+        std::fs::create_dir(&mount_point).unwrap();
+        let entry = std::fs::read_dir(root.path())
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap();
+        let mut walk_data = create_walker(false);
+        walk_data.excluded_mounts.insert(mount_point);
+
+        assert!(ignore_file(&entry, &walk_data));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ use std::cmp::max;
 use std::path::PathBuf;
 use terminal_size::{Height, Width, terminal_size};
 use utils::get_filesystem_devices;
+use utils::get_mount_points;
 use utils::simplify_dir_names;
 
 static DEFAULT_NUMBER_OF_LINES: usize = 30;
@@ -213,6 +214,12 @@ fn main() {
 
     let simplified_dirs = simplify_dir_names(&target_dirs);
 
+    let excluded_mounts = if config.get_exclude_mounts(&options) {
+        get_mount_points(&simplified_dirs)
+    } else {
+        Default::default()
+    };
+
     let ignored_full_path: HashSet<PathBuf> = ignore_directories
         .into_iter()
         .flat_map(|x| simplified_dirs.iter().map(move |d| d.join(&x)))
@@ -246,6 +253,7 @@ fn main() {
 
     let walk_data = WalkData {
         ignore_directories: ignored_full_path,
+        excluded_mounts,
         filter_regex: &filter_regexs,
         invert_filter_regex: &invert_filter_regexs,
         allowed_filesystems,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,7 @@
 use platform::get_metadata;
 use std::collections::HashSet;
+#[cfg(target_os = "linux")]
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use crate::config::DAY_SECONDS;
@@ -54,6 +56,85 @@ pub fn get_filesystem_devices<P: AsRef<Path>>(paths: &[P], follow_links: bool) -
                 _ => None,
             }
         })
+        .collect()
+}
+
+pub fn get_mount_points<P: AsRef<Path>>(targets: &HashSet<P>) -> HashSet<PathBuf> {
+    map_mount_points(targets, &system_mount_points())
+}
+
+fn map_mount_points<P: AsRef<Path>>(
+    targets: &HashSet<P>,
+    mount_points: &HashSet<PathBuf>,
+) -> HashSet<PathBuf> {
+    targets
+        .iter()
+        .filter_map(|target| {
+            let walked_root = normalize_path(target);
+            std::fs::canonicalize(&walked_root)
+                .ok()
+                .map(|absolute_root| (walked_root, absolute_root))
+        })
+        .flat_map(|(walked_root, absolute_root)| {
+            mount_points.iter().filter_map(move |mount_point| {
+                let relative = mount_point.strip_prefix(&absolute_root).ok()?;
+                if relative.as_os_str().is_empty() {
+                    None
+                } else {
+                    Some(walked_root.join(relative))
+                }
+            })
+        })
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn system_mount_points() -> HashSet<PathBuf> {
+    std::fs::read("/proc/self/mountinfo")
+        .map(|contents| linux_mount_points_from(&contents))
+        .unwrap_or_default()
+}
+
+#[cfg(target_os = "linux")]
+fn linux_mount_points_from(contents: &[u8]) -> HashSet<PathBuf> {
+    use std::os::unix::ffi::OsStringExt;
+
+    contents
+        .split(|byte| *byte == b'\n')
+        .filter_map(|line| line.split(|byte| *byte == b' ').nth(4))
+        .map(unescape_mount_path)
+        .map(OsString::from_vec)
+        .map(PathBuf::from)
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn unescape_mount_path(path: &[u8]) -> Vec<u8> {
+    let mut unescaped = Vec::with_capacity(path.len());
+    let mut index = 0;
+    while index < path.len() {
+        if path[index] == b'\\'
+            && let Some(octal) = path.get(index + 1..index + 4)
+            && octal.iter().all(|byte| matches!(byte, b'0'..=b'7'))
+        {
+            unescaped.push((octal[0] - b'0') * 64 + (octal[1] - b'0') * 8 + octal[2] - b'0');
+            index += 4;
+        } else {
+            unescaped.push(path[index]);
+            index += 1;
+        }
+    }
+    unescaped
+}
+
+#[cfg(not(target_os = "linux"))]
+fn system_mount_points() -> HashSet<PathBuf> {
+    use sysinfo::Disks;
+
+    Disks::new_with_refreshed_list()
+        .list()
+        .iter()
+        .map(|disk| disk.mount_point().to_path_buf())
         .collect()
 }
 
@@ -117,6 +198,41 @@ fn is_a_parent_of<P: AsRef<Path>>(parent: P, child: P) -> bool {
 mod tests {
     #[allow(unused_imports)]
     use super::*;
+
+    #[test]
+    fn test_map_mount_points_excludes_descendants_but_not_target() {
+        let root = tempfile::tempdir().unwrap();
+        let nested_mount = root.path().join("nested");
+        let deeper_mount = nested_mount.join("deeper");
+        let outside_mount = root.path().with_extension("outside");
+        std::fs::create_dir(&nested_mount).unwrap();
+        std::fs::create_dir(&deeper_mount).unwrap();
+
+        let targets = HashSet::from([root.path().to_path_buf()]);
+        let mounts = HashSet::from([
+            root.path().to_path_buf(),
+            nested_mount.clone(),
+            deeper_mount.clone(),
+            outside_mount,
+        ]);
+
+        assert_eq!(
+            map_mount_points(&targets, &mounts),
+            HashSet::from([nested_mount, deeper_mount])
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_linux_mount_points_from_decodes_mountinfo_paths() {
+        let mountinfo = b"36 25 0:32 / / rw - ext4 /dev/root rw\n\
+                          37 36 0:33 / /mnt/with\\040space\\134slash rw - ext4 /dev/test rw\n";
+
+        assert_eq!(
+            linux_mount_points_from(mountinfo),
+            HashSet::from([PathBuf::from("/"), PathBuf::from("/mnt/with space\\slash")])
+        );
+    }
 
     #[test]
     fn test_simplify_dir() {


### PR DESCRIPTION
## Why

I use `dust` to list immediate project sizes before moving directories between disks, and I want mounted directories omitted explicitly.

For my current tree, `-x` produces the same result because the mounted child is on another filesystem. But `-x` checks filesystem device metadata throughout the walk, while an explicit mount-point filter can skip known mount targets directly. It also covers same-filesystem bind mounts, which device-ID filtering cannot distinguish from ordinary directories.

Paired local timings with byte-identical JSON output:

- `dust -d 1 -D -x`: 28.7 seconds
- `dust -d 1 -D --exclude-mounts`: 20.9 seconds

## What changed

`--exclude-mounts` skips mount points below each supplied path while still allowing a supplied path that is itself mounted.

On Linux it reads `/proc/self/mountinfo`, which covers same-device bind mounts. Other platforms use the existing `sysinfo` disk mount-point inventory. The option is also available as `exclude-mounts=true` in the config file.

The README, sample config, man page, and generated shell completions are updated.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets` - 80 tests passed
- `cargo clippy -- -D warnings`
- `cargo check --target x86_64-pc-windows-gnu`
- Isolated Linux test with source and bind target on the same device

OpenAI Codex assisted with code generation, testing, and review. I reviewed and validated the final patch, and the commit includes an `Assisted-by` trailer.