### PR TITLE
deps: bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Fixes #601.

## What's broken

`Cargo.lock` pins `crossbeam-epoch 0.9.18`, which RUSTSEC-2026-0204 covers. It is a transitive dependency, rayon 1.11 to rayon-core 1.13 to crossbeam-deque 0.8.6.

The advisory is a null pointer dereference in the `fmt::Pointer` impl for `Atomic` and `Shared`, patched in 0.9.20.

## The fix

`cargo update -p crossbeam-epoch`. Two lines in the lockfile, nothing in `Cargo.toml`, since it already declares `rayon = "1"` and the bump is semver compatible. dust ships a binary, so the lockfile is the right place for this.

## Verification

```
Updating crossbeam-epoch v0.9.18 -> v0.9.20
```

`cargo build --release` succeeds and the whole test suite passes: 32, 8, 31 and 4 tests across the four targets, zero failures.

One thing to note that is not from this change: `cargo clippy --all-targets -- -D warnings` currently fails on master with four `empty_line_after_doc_comments` errors in the test files, a lint that Rust 1.97 turned on. I confirmed those are present on a clean tree with my change stashed, so they are unrelated to this PR, but CI may be red until someone fixes them.

I did not run `cargo audit` myself, it is not installed here. I verified the pinned version and the advisory's patched range directly instead.
