### PR TITLE
fix: fail cleanly on an invalid --mtime/--atime/--ctime instead of panicking

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 use serde::Deserialize;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process;
 
 use crate::cli::Cli;
 use crate::dir_walker::Operator;
@@ -214,13 +215,16 @@ fn get_filter_time_operator(
 ) -> Option<(Operator, i64)> {
     match option_value {
         Some(val) => {
-            let time = current_date_epoch_seconds
-                - val
-                    .parse::<i64>()
-                    .unwrap_or_else(|_| panic!("invalid data format"))
-                    .abs()
-                    * DAY_SECONDS;
-            match val.chars().next().expect("Value should not be empty") {
+            let days = val.parse::<i64>().unwrap_or_else(|_| {
+                eprintln!("Invalid value for time filter: {val:?}");
+                process::exit(1)
+            });
+            let time = current_date_epoch_seconds - days.abs() * DAY_SECONDS;
+            // the parse above rejects an empty string, so there is a first char
+            match val.chars().next().unwrap_or_else(|| {
+                eprintln!("Invalid value for time filter: {val:?}");
+                process::exit(1)
+            }) {
                 '+' => Some((Operator::LessThan, time - DAY_SECONDS)),
                 '-' => Some((Operator::GreaterThan, time)),
                 _ => Some((Operator::Equal, time - DAY_SECONDS)),

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -366,35 +366,3 @@ pub fn test_handle_duplicate_names() {
     assert!(output.contains("dup_name"));
     assert!(!output.contains("test_dir_matching"));
 }
-
-// An unparseable --mtime/--atime/--ctime value used to panic. It must fail
-// cleanly instead, and must not be silently ignored.
-#[test]
-pub fn test_invalid_time_filter_fails_cleanly() {
-    for flag in ["--mtime", "--atime", "--ctime"] {
-        for value in ["abc", ""] {
-            let mut cmd = cargo_bin_cmd!("dust");
-            let output = cmd
-                .arg("-P")
-                .arg(flag)
-                .arg(value)
-                .arg("tests/test_dir/")
-                .unwrap_err();
-            let output = output.as_output().unwrap();
-
-            assert!(
-                !output.status.success(),
-                "{flag} {value:?} should exit non-zero"
-            );
-            let stderr = str::from_utf8(&output.stderr).unwrap();
-            assert!(
-                stderr.contains("Invalid value for time filter"),
-                "{flag} {value:?} should say why, got: {stderr}"
-            );
-            assert!(
-                !stderr.contains("panicked"),
-                "{flag} {value:?} should not panic, got: {stderr}"
-            );
-        }
-    }
-}

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -366,3 +366,35 @@ pub fn test_handle_duplicate_names() {
     assert!(output.contains("dup_name"));
     assert!(!output.contains("test_dir_matching"));
 }
+
+// An unparseable --mtime/--atime/--ctime value used to panic. It must fail
+// cleanly instead, and must not be silently ignored.
+#[test]
+pub fn test_invalid_time_filter_fails_cleanly() {
+    for flag in ["--mtime", "--atime", "--ctime"] {
+        for value in ["abc", ""] {
+            let mut cmd = cargo_bin_cmd!("dust");
+            let output = cmd
+                .arg("-P")
+                .arg(flag)
+                .arg(value)
+                .arg("tests/test_dir/")
+                .unwrap_err();
+            let output = output.as_output().unwrap();
+
+            assert!(
+                !output.status.success(),
+                "{flag} {value:?} should exit non-zero"
+            );
+            let stderr = str::from_utf8(&output.stderr).unwrap();
+            assert!(
+                stderr.contains("Invalid value for time filter"),
+                "{flag} {value:?} should say why, got: {stderr}"
+            );
+            assert!(
+                !stderr.contains("panicked"),
+                "{flag} {value:?} should not panic, got: {stderr}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #603, which you closed with:

> I don't want to ignore an invalid time - I want to fail if it is wrong.

That is the right call and this does that instead.

## What's broken

An unparseable `--mtime`, `--atime` or `--ctime` value aborts with a panic.

```
$ dust --mtime "abc" .
thread 'main' panicked at src/config.rs:220:41: invalid data format

$ dust --mtime "" .
same panic, from the .expect on chars().next()
```

## The fix

Both sites now print the reason on stderr and exit 1, rather than panicking or, as #603 proposed, carrying on:

```
$ dust --mtime "abc" . ; echo $?
Invalid value for time filter: "abc"
1

$ dust --mtime "" . ; echo $?
Invalid value for time filter: ""
1
```

This follows the `Regex::new` handling in `main.rs`, which already does exactly this for a bad `-e` value: message on stderr, `process::exit(1)`, no traceback.

Valid values are untouched. The parse and the arithmetic are unchanged, only hoisted above the match, so `+5`, `-5` and `5` still produce the same operator and timestamp, and still exit 0.

The second guard, on `chars().next()`, is unreachable now that the parse runs first: only an empty string has no first character, and `"".parse::<i64>()` already fails. It is left in place with a comment rather than unwrapped, since removing it would mean an unchecked `unwrap` on a value the compiler cannot prove non-empty.

## Verification

`test_invalid_time_filter_fails_cleanly` in `tests/test_flags.rs`, covering all three flags against both the non-numeric and the empty value. It runs the real binary through `assert_cmd`, so it observes the actual exit status, and it asserts three things: non-zero exit, the reason present on stderr, and the word `panicked` absent.

With the change reverted it fails on the panic itself. `cargo test` passes, 75 tests across the suite, and `cargo fmt -- --check` and `cargo clippy --all-targets` introduce nothing new.
