### PR TITLE
fix: -t with -m sums timestamps instead of taking the newest

### DIFF
--- a/src/filter_type.rs
+++ b/src/filter_type.rs
@@ -18,7 +18,11 @@ pub fn get_all_file_types(
 ) -> DisplayNode {
     let ext_nodes = {
         let mut extension_cumulative_sizes = HashMap::new();
-        build_by_all_file_types(top_level_nodes, &mut extension_cumulative_sizes);
+        build_by_all_file_types(
+            top_level_nodes,
+            &mut extension_cumulative_sizes,
+            by_filetime,
+        );
 
         let mut extension_cumulative_sizes: Vec<ExtensionNode<'_>> = extension_cumulative_sizes
             .iter()
@@ -77,13 +81,19 @@ pub fn get_all_file_types(
 fn build_by_all_file_types<'a>(
     top_level_nodes: &'a [Node],
     counter: &mut HashMap<Option<&'a OsStr>, u64>,
+    by_filetime: &Option<FileTime>,
 ) {
     for node in top_level_nodes {
         if node.name.is_file() {
             let ext = node.name.extension();
             let cumulative_size = counter.entry(ext).or_default();
-            *cumulative_size += node.size;
+            if by_filetime.is_some() {
+                // 'size' is a timestamp, summing them is meaningless
+                *cumulative_size = (*cumulative_size).max(node.size);
+            } else {
+                *cumulative_size += node.size;
+            }
         }
-        build_by_all_file_types(&node.children, counter)
+        build_by_all_file_types(&node.children, counter, by_filetime)
     }
 }

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -352,6 +352,30 @@ pub fn test_collapse() {
 }
 
 #[test]
+pub fn test_show_files_by_type_with_filetime() {
+    // When grouping by file type and showing filetimes, the 'size' of a group is
+    // a timestamp: it must be the newest file's time, not the sum of the times.
+    use std::fs::File;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    let dir = tempfile::Builder::new().tempdir().unwrap();
+
+    // Midday UTC, so the year is the same in every timezone
+    for epoch_seconds in [1593604800, 1625140800, 1656676800] {
+        let file = File::create(dir.path().join(format!("{epoch_seconds}.log"))).unwrap();
+        file.set_modified(UNIX_EPOCH + Duration::from_secs(epoch_seconds))
+            .unwrap();
+    }
+
+    let output = build_command(vec!["-c", "-t", "-m", "m", dir.path().to_str().unwrap()]);
+
+    // 1656676800 is 2022-07-01, the newest of the three
+    assert!(output.contains("2022-07-0"), "{output}");
+    assert!(!output.contains("2020-07-0"), "{output}");
+    assert!(!output.contains("2021-07-0"), "{output}");
+}
+
+#[test]
 pub fn test_handle_duplicate_names() {
     // Check that even if we run on a multiple directories with the same name
     // we still show the distinct parent dir in the output

--- a/tests/test_flags.rs
+++ b/tests/test_flags.rs
@@ -351,9 +351,13 @@ pub fn test_collapse() {
     assert!(!output.contains("hello_file"));
 }
 
+// Unix only: on windows the metadata time is a FILETIME (100ns ticks since
+// 1601), not a unix epoch, so `-m` panics in get_pretty_file_modified_time.
+// That is pre-existing and unrelated to this fix.
+#[cfg(target_family = "unix")]
 #[test]
 pub fn test_show_files_by_type_with_filetime() {
-    // When grouping by file type and showing filetimes, the 'size' of a group is
+    // When grouping by file type and showing file times, the 'size' of a group is
     // a timestamp: it must be the newest file's time, not the sum of the times.
     use std::fs::File;
     use std::time::{Duration, UNIX_EPOCH};


### PR DESCRIPTION
`-t` (group by file type) combined with `-m` (show filetimes) adds the timestamps
together, so every group shows a date a century in the future.

Three `.log` files with mtimes 2020-01-01, 2021-06-15 and 2022-03-10:

```
$ dust -P -c -w 60 -t -m m demo
before:
2123-08-24T12:00:00   ┌──.log
2123-08-24T12:00:00 ┌─┴(total)

after:
2022-03-10T12:00:00   ┌──.log
2022-03-10T12:00:00 ┌─┴(total)
```

The same tree without `-t` already prints 2020, 2021 and 2022 correctly, which is
the reference the grouped view should agree with.

## Cause

When `by_filetime` is set, `node.size` holds a timestamp rather than a size, and
`get_all_file_types` already knows that in two places:

```rust
let actual_size = if by_filetime.is_some() {
    ext_nodes_iter.map(|node| node.size).max().unwrap_or(0)
} else {
    ext_nodes_iter.map(|node| node.size).sum()
};
```

The per-extension accumulator in `build_by_all_file_types` was not given the same
treatment, so it keeps doing `*cumulative_size += node.size` and sums epochs.

## The fix

Pass `by_filetime` down and take the max instead of the sum in that one branch,
matching what the surrounding code already does. Size mode is untouched.

## Verification

`test_show_files_by_type_with_filetime` builds the three files above and asserts
the rendered date.

Reverting only the branch back to `+=` fails it, and the failure output is the
symptom itself:

```
test test_show_files_by_type_with_filetime ... FAILED
2124-06-30T12:00:00   ┌──.log
2124-06-30T12:00:00 ┌─┴(total)
```

I kept a test here rather than going test-free as on #609: this one needs real
files on disk, since `build_by_all_file_types` only counts nodes where
`node.name.is_file()`, so it is not the kind of one-line config change that
reads correct on sight. The timestamps are set at midday UTC so the assertion
holds regardless of the runner's timezone.

`cargo test` is 31 + 8 + 32 + 4 passed, 0 failed. `cargo fmt --check` clean.
`cargo clippy` reports the same two pre-existing "empty line after doc comment"
warnings before and after, in files I did not touch.

*Disclosure: written with AI assistance (Claude Code). I built binaries from master and from the patched tree and produced the before and after above by running them, and ran the mutation check myself.*
