### PR TITLE
fix: a wide-character filename overflows the requested width

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -4,7 +4,7 @@ use crate::node::FileTime;
 use lscolors::{LsColors, Style};
 use nu_ansi_term::Color::{DarkGray, Red};
 
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use stfu8::encode_u8;
 
@@ -314,7 +314,18 @@ fn maybe_trim_filename(name_in: String, indent: &str, display_data: &DisplayData
 
     let max_size = display_data.longest_string_length - indent_length;
     if UnicodeWidthStr::width(&*name_in) > max_size {
-        let name = name_in.chars().take(max_size - 2).collect::<String>();
+        // Truncate by display width, not by char count: wide characters (CJK,
+        // emoji) take 2 columns each, so taking 'n' chars can overflow the line.
+        let mut width_left = max_size - 2;
+        let mut name = String::new();
+        for c in name_in.chars() {
+            let char_width = UnicodeWidthChar::width(c).unwrap_or(0);
+            if char_width > width_left {
+                break;
+            }
+            width_left -= char_width;
+            name.push(c);
+        }
         name + ".."
     } else {
         name_in
@@ -543,6 +554,28 @@ mod tests {
             s,
             "4.0Ki ┌─┴ very_long_name_longer_than_the_eighty_character_limit_very_.."
         );
+    }
+
+    #[test]
+    fn test_format_str_long_name_wide_chars() {
+        // Wide (2 column) characters must be truncated by display width, not by
+        // char count, otherwise the line overflows the terminal.
+        let name = "ラウトは難しいですラウトは難しいですラウトは難しいです";
+        let n = DisplayNode {
+            name: PathBuf::from(name),
+            size: 2_u64.pow(12),
+            children: vec![],
+        };
+        let indent = "┌─┴";
+        let percent_bar = "";
+        let is_biggest = false;
+
+        // longest_string_length of 20 leaves 20 - 3 = 17 columns for the name,
+        // of which 2 are the '..' marker: 7 wide chars (14 cols) then '..'
+        let data = get_fake_display_data(20);
+        let s = format_string(&n, indent, percent_bar, is_biggest, &data);
+        assert_eq!(s, "4.0Ki ┌─┴ ラウトは難しい..");
+        assert_eq!(UnicodeWidthStr::width(&*s), 26);
     }
 
     #[test]


### PR DESCRIPTION
A filename containing wide characters (CJK, emoji) overflows the requested width,
because the name is measured in columns but truncated in characters.

A directory whose name is 26 CJK characters, with `dust -P -c -w 40`. Measuring
the real display width of the output:

```
before: 66 columns
after:  40 columns
```

The 40-column request produced a 66-column line, 65% over. Verified the same way
at `-w 24`, `-w 40`, `-w 50` and `-w 60`: after the change every line fits
exactly within the requested width.

## Cause

`maybe_trim_filename` measures with `UnicodeWidthStr::width` and then cuts with
`chars().take(...)`:

```rust
if UnicodeWidthStr::width(&*name_in) > max_size {
    let name = name_in.chars().take(max_size - 2).collect::<String>();
```

Each CJK character is one `char` but two columns, so taking `max_size - 2`
characters yields roughly twice that many columns. This is the path used when
bars are off (`-b`, or when the tree is too wide for them).

## The fix

Accumulate characters while their widths fit in the budget, instead of counting
them. ASCII behaviour is unchanged, since there one character is one column, and
the existing `test_format_str_long_name` confirms it.

## Verification

`test_format_str_long_name_wide_chars` asserts both the exact resulting string
and its rendered width, so an off-by-one would also fail it.

Reverting to `chars().take(max_size - 2)` fails it:

```
assertion `left == right` failed
  left: "4.0Ki ┌─┴ ラウトは難しいですラウトは難し.."
 right: "4.0Ki ┌─┴ ラウトは難しい.."
```

`cargo test` is 32 + 8 + 31 + 4 passed, 0 failed. `cargo fmt --check` clean, and
`cargo clippy` shows the same 4 pre-existing warnings as master.

I kept a test here rather than going test-free as on #609: this replaces a single
expression with a loop, so its correctness does not read off the diff the way a
one-line config fix does.

*Disclosure: written with AI assistance (Claude Code). I built binaries from master and from the patched tree and measured the real display width of their output, and ran the mutation check myself.*
