### PR TITLE
ci: enforce the committed lockfile

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo fmt --all -- --check
       - name: clippy
         if: success() || failure() # run regardless of fmt outcome
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --locked -- -D warnings
 
   build:
     name: Build
@@ -159,7 +159,7 @@ jobs:
         run: |
           RUNNER=cargo
           [ -n "${{ steps.vars.outputs.CARGO_USE_CROSS }}" ] && RUNNER=cross
-          $RUNNER build --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+          $RUNNER build --locked --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
 
       - name: Install cargo-deb
         if: matrix.job.target == 'i686-unknown-linux-musl' || matrix.job.target == 'x86_64-unknown-linux-musl'
@@ -177,7 +177,7 @@ jobs:
         run: |
           RUNNER=cargo
           [ -n "${{ steps.vars.outputs.CARGO_USE_CROSS }}" ] && RUNNER=cross
-          $RUNNER test --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+          $RUNNER test --locked --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
 
       - name: Archive executable artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- add `--locked` to Clippy
- pass `--locked` through both Cargo and cross build/test paths
- ensure CI and release artifacts use the committed dependency resolution

Dust is a binary application with a committed `Cargo.lock`. Without `--locked`, Cargo can repair manifest/lockfile drift only inside a runner, leaving normal CI green while a stricter downstream or release invocation fails.

## Validation

- `cargo check --locked --all-targets`
- `git diff --check`

Prepared with assistance from OpenAI Codex; the commit includes a `Co-authored-by` trailer.