### PR TITLE
fix: -t draws the (others) row out of size order

### DIFF
--- a/src/filter_type.rs
+++ b/src/filter_type.rs
@@ -59,6 +59,9 @@ pub fn get_all_file_types(
             size: actual_size,
             children: vec![],
         });
+        // '(others)' is the sum of the remaining nodes so it can be bigger than
+        // the nodes above it: re-sort so the tree stays in size order.
+        displayed.sort_by(|lhs, rhs| lhs.cmp(rhs).reverse());
     }
 
     let actual_size: u64 = if by_filetime.is_some() {
@@ -85,5 +88,46 @@ fn build_by_all_file_types<'a>(
             *cumulative_size += node.size;
         }
         build_by_all_file_types(&node.children, counter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file_node(name: &str, size: u64) -> Node {
+        Node {
+            name: PathBuf::from(name),
+            size,
+            children: vec![],
+            inode_device: None,
+            depth: 1,
+        }
+    }
+
+    #[test]
+    fn test_others_node_is_sorted_by_size() {
+        // These must be real files: only files are counted by extension.
+        // Their sizes come from the Node, not from disk.
+        let nodes = vec![
+            file_node("Cargo.toml", 40),
+            file_node("README.md", 30),
+            file_node("build.rs", 20),
+            file_node("Cargo.lock", 10),
+        ];
+
+        // 2 lines: '.toml' then '(others)', which sums to 60 and so must sort first
+        let tree = get_all_file_types(&nodes, 2, &None);
+
+        assert_eq!(tree.size, 100);
+        let displayed: Vec<_> = tree
+            .children
+            .iter()
+            .map(|c| (c.name.to_string_lossy().to_string(), c.size))
+            .collect();
+        assert_eq!(
+            displayed,
+            vec![("(others)".to_string(), 60), (".toml".to_string(), 40)]
+        );
     }
 }


### PR DESCRIPTION
With `-t`, the aggregated `(others)` row is appended after the list is sorted, so when its total is larger than the rows above it the tree comes out in the wrong order and the "biggest" highlight lands on the wrong row.

Four files of 40Ki, 30Ki, 20Ki and 10Ki, shown with `-t -n 2`:

```
before    64Ki   ┌── (others)
          40Ki   ├── .bin          <- 40Ki drawn below 64Ki
         104Ki ┌─┴ (total)

after     40Ki   ┌── .bin
          64Ki   ├── (others)
         104Ki ┌─┴ (total)
```

The after order matches how dust draws a normal listing, where the largest sits nearest the total. The list is re-sorted once the `(others)` node has been pushed, inside the branch that creates it, so output without an `(others)` row is unchanged.

Test added in `src/filter_type.rs`; removing the sort fails it. `cargo test` passes, 33 plus 8 plus 31 plus 4. `cargo fmt --check` clean; the 4 clippy warnings in `tests/` are pre-existing and identical on an unmodified checkout.

AI disclosure: written with Claude Code. I ran the binary before and after and checked the mutation myself.