### PR TITLE
Update clap_mangen build dependency from 0.2 to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.33"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+checksum = "211d617eaa4b735c96c9e0228fcbdb5120ef623f2b8cb67ffb84c3e02dbc28a4"
 dependencies = [
  "clap",
  "roff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tempfile = "=3"
 [build-dependencies]
 clap = { version = "4.4", features = ["derive"] }
 clap_complete = "4.4"
-clap_mangen = "0.2"
+clap_mangen = "0.3"
 
 [[test]]
 name = "integration"


### PR DESCRIPTION
https://github.com/clap-rs/clap/blob/clap_mangen-v0.3.3/clap_mangen/CHANGELOG.md

This didn’t require any source-code changes. Tested with `cargo test` and a quick visual inspection of the generated man page.